### PR TITLE
Add Oracle Siebel and PeopleSoft ingestion examples

### DIFF
--- a/data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb
+++ b/data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb
@@ -155,6 +155,50 @@
     "    .option(\"host.name.verification\", \"true\") \\\n",
     "    .load().show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35578e34-9b9a-46ec-b3f3-bde0498a9649",
+   "metadata": {
+    "type": "python"
+   },
+   "outputs": [],
+   "source": [
+    "# Oracle Siebel\n",
+    "spark.read.format(\"aidataplatform\") \\\n",
+    "    .option(\"type\", \"ORACLE_SIEBEL\") \\\n",
+    "    .option(\"host\", \"<host>\") \\\n",
+    "    .option(\"port\", \"\") \\\n",
+    "    .option(\"database.name\", \"\") \\\n",
+    "    .option(\"user.name\", \"<user_name>\") \\\n",
+    "    .option(\"password\", \"<password>\") \\\n",
+    "    .option(\"schema\", \"<schema>\") \\\n",
+    "    .option(\"table\", \"\") \\\n",
+    "    .load().show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7fbc818-9f1d-42aa-b675-d225f34ff4e5",
+   "metadata": {
+    "type": "python"
+   },
+   "outputs": [],
+   "source": [
+    "# Oracle Peoplesoft\n",
+    "spark.read.format(\"aidataplatform\") \\\n",
+    "    .option(\"type\", \"ORACLE_PEOPLESOFT\") \\\n",
+    "    .option(\"host\", \"<host>\") \\\n",
+    "    .option(\"port\", \"\") \\\n",
+    "    .option(\"database.name\", \"\") \\\n",
+    "    .option(\"user.name\", \"<user_name>\") \\\n",
+    "    .option(\"password\", \"<password>\") \\\n",
+    "    .option(\"schema\", \"<schema>\") \\\n",
+    "    .option(\"table\", \"\") \\\n",
+    "    .load().show()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Adds two read-only Spark connector examples (`ORACLE_SIEBEL`, `ORACLE_PEOPLESOFT`) to `data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb`.
- Cell IDs are unique (no collision with existing FUSION_BICC cell).

Re-commits #40 under a signed-OCA author. Original work by @vishaldhiman22 (credited via `Co-authored-by`).

Closes #40.