### PR TITLE
ai/claude-code-plugins: spark-connectors v0.5.0 (5 new connectors + pushdown/catalog/manifest patterns)

### DIFF
--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/.claude-plugin/plugin.json
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "oracle-ai-data-platform-workbench-spark-connectors",
-  "version": "0.4.1",
-  "description": "Oracle AI Data Platform Workbench Spark connectors for Claude Code. 18 connector skills covering every data source workbench customers commonly need: Oracle Autonomous DB family (ALH/ADW/ATP) via wallet/IAM-DB-Token/API-key, ExaCS, Fusion ERP REST, Fusion BICC, EPM Cloud Planning, Essbase 21c, OCI Streaming (Kafka), OCI Object Storage, Apache Iceberg, plus external systems (PostgreSQL, MySQL/HeatWave, SQL Server, Snowflake, Azure ADLS Gen2, AWS S3, generic REST, custom JDBC, Excel). Live-validated on the workbench `tpcds` cluster (Spark 3.5.0): 17 PASS / 4 ship-as-is out of 21 test rows.",
+  "version": "0.5.0",
+  "description": "Oracle AI Data Platform Workbench Spark connectors for Claude Code. 23 connector skills covering every data source workbench customers commonly need: Oracle Autonomous DB family (ALH/ADW/ATP) via wallet/IAM-DB-Token/API-key, generic Oracle Database, ExaCS, Oracle PeopleSoft, Oracle Siebel, Fusion ERP REST, Fusion BICC, EPM Cloud Planning, Essbase 21c, OCI Streaming (Kafka), OCI Object Storage, Apache Iceberg, plus PostgreSQL, MySQL/HeatWave, SQL Server, Apache Hive, Salesforce, Snowflake, Azure ADLS Gen2, AWS S3, generic REST, custom JDBC, and Excel. v0.5.0 adds 5 new connectors plus pushdown.sql / catalog.id / manifest.path patterns from oracle-samples PR #46.",
   "author": {
     "name": "Ahmed Awan"
   },
-  "homepage": "https://github.com/ahmedawan-oracle/oracle-ai-data-platform-workbench-spark-connectors",
-  "repository": "https://github.com/ahmedawan-oracle/oracle-ai-data-platform-workbench-spark-connectors",
+  "homepage": "https://github.com/oracle-samples/oracle-aidp-samples/tree/main/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors",
+  "repository": "https://github.com/oracle-samples/oracle-aidp-samples",
   "license": "MIT",
   "keywords": [
     "oracle",
@@ -32,6 +32,12 @@
     "adls",
     "s3",
     "rest",
-    "connector"
+    "connector",
+    "peoplesoft",
+    "siebel",
+    "salesforce",
+    "hive",
+    "pushdown",
+    "catalog"
   ]
 }

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/CHANGELOG.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/CHANGELOG.md
@@ -43,9 +43,9 @@ Adds 5 new connectors and adopts the v1.0 sample patterns from [`oracle-samples/
 - **`aidp-rest-generic`**: added a new section documenting the `manifest.path` (workspace/Volume) pattern alongside the original `manifest.url` pattern.
 - **`scripts/oracle_ai_data_platform_connectors/aidataplatform.py`**: docstring updated to list the new connector types and the new common-extras (`write.mode`, `write.merge.keys`, `pushdown.sql`, `catalog.id`, `manifest.path`).
 
-### Live-test status (unchanged from v0.4.x)
+### Validation
 
-The 5 new connectors ship as-is — they wrap the same `aidataplatform` format handler that the oracle-samples team validates upstream. The `aidp-oracle-db` skill has the same code path as `aidp-postgresql` / `aidp-mysql` / `aidp-sqlserver`, all of which were live-validated in v0.3.0+. The 17 PASS / 4 ship-as-is matrix from v0.4.0 carries forward unchanged.
+The 5 new connectors wrap the same `aidataplatform` format handler that the oracle-samples team validates upstream — the `aidp-oracle-db` skill in particular shares its code path with `aidp-postgresql` / `aidp-mysql` / `aidp-sqlserver`. Plugin shape: `claude plugin validate .` ✓; unit tests: 53/53 ✓.
 
 ## [0.4.1] — 2026-04-28
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/CHANGELOG.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to this plugin are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this plugin adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — 2026-05-07
+
+Adds 5 new connectors and adopts the v1.0 sample patterns from [`oracle-samples/oracle-aidp-samples` PR #46](https://github.com/oracle-samples/oracle-aidp-samples/pull/46) (`pushdown.sql`, `catalog.id`, `manifest.path`, `write.mode=MERGE`).
+
+### Added — 5 new connector skills (23 total, was 18)
+
+| Skill | Target | aidataplatform `type` |
+|---|---|---|
+| **`aidp-oracle-db`** | Generic Oracle Database (Compute / Base DB / on-prem / 19c-26ai non-Autonomous) — read-write | `ORACLE_DB` |
+| **`aidp-peoplesoft`** | Oracle PeopleSoft (HCM, FSCM, Campus Solutions) — read-only | `ORACLE_PEOPLESOFT` |
+| **`aidp-siebel`** | Oracle Siebel CRM — read-only | `ORACLE_SIEBEL` |
+| **`aidp-salesforce`** | Salesforce (Sales/Service Cloud, custom sObjects) — read-only | `SFORCE` (note: literal type is `SFORCE`, not `SALESFORCE`) |
+| **`aidp-hive`** | Apache Hive (HiveServer2, non-Kerberos) — read-write | `HIVE` |
+
+### Added — cross-cutting patterns from oracle-samples PR #46
+
+- **`pushdown.sql`** — push complete source SQL queries at the database, skipping schema/table option building. Documented in every applicable connector skill.
+- **`catalog.id`** — reference pre-registered AIDP external catalogs by id, replacing host/port/user/password. Pairs with three-part `spark.table()` and `saveAsTable()` for the cleanest read/write code. Documented in `aidp-oracle-db`.
+- **`manifest.path`** — REST manifest as a workspace/Volume path instead of an HTTP URL. Documented in `aidp-rest-generic`.
+- **`write.mode` MERGE + `write.merge.keys`** — merge writes via the format handler.
+
+### Added — example notebooks
+
+5 new notebooks under `examples/` (one per new skill), copied directly from the canonical `oracle-samples` PR #46:
+
+- `examples/oracle_db_read_write.ipynb`
+- `examples/peoplesoft_read.ipynb`
+- `examples/siebel_read.ipynb`
+- `examples/salesforce_read.ipynb`
+- `examples/hive_read_write.ipynb`
+
+### Added — unit tests
+
+8 new unit tests in `tests/test_aidataplatform.py` covering each new `type` value, the `catalog.id` shape, `pushdown.sql` shape, `write.mode=MERGE` with `write.merge.keys`, and `manifest.path` for REST. Test count: 45 → **53 passing**.
+
+### Changed — existing skills
+
+- **`aidp-connectors-overview`** (routing): expanded keyword list and added new sections — RDBMS/Hadoop now covers Hive, new SaaS section for Salesforce, expanded Oracle/OCI section for PeopleSoft / Siebel / generic Oracle DB.
+- **`aidp-rest-generic`**: added a new section documenting the `manifest.path` (workspace/Volume) pattern alongside the original `manifest.url` pattern.
+- **`scripts/oracle_ai_data_platform_connectors/aidataplatform.py`**: docstring updated to list the new connector types and the new common-extras (`write.mode`, `write.merge.keys`, `pushdown.sql`, `catalog.id`, `manifest.path`).
+
+### Live-test status (unchanged from v0.4.x)
+
+The 5 new connectors ship as-is — they wrap the same `aidataplatform` format handler that the oracle-samples team validates upstream. The `aidp-oracle-db` skill has the same code path as `aidp-postgresql` / `aidp-mysql` / `aidp-sqlserver`, all of which were live-validated in v0.3.0+. The 17 PASS / 4 ship-as-is matrix from v0.4.0 carries forward unchanged.
+
 ## [0.4.1] — 2026-04-28
 
 Documentation-only release. Plugin code, skills, and helpers are unchanged from `0.4.0`.

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/CHANGELOG.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/CHANGELOG.md
@@ -59,10 +59,10 @@ Documentation-only release. Plugin code, skills, and helpers are unchanged from 
 
 ## [0.4.0] — 2026-04-27
 
-First public-marketplace-ready release. Live-validated end-to-end on AIDP `tpcds` cluster (Spark 3.5.0).
+First public-marketplace-ready release.
 
 ### Highlights
-- **17 of 21 live-test rows PASS**, 4 ship-as-is (customer-supplied endpoints): MySQL, SQL Server, Azure ADLS, generic REST manifest.
+- 4 connectors ship as-is (customer-supplied endpoints): MySQL, SQL Server, Azure ADLS, generic REST manifest.
 - **18 connector skills** + bootstrap + routing, every one with an action-oriented `description:` for Claude Code skill discovery.
 - **Zero DEFERRED rows.** All previously deferred BDS / DB-token / catalog-sync / VCN-routing items are either flipped to PASS, rolled into ship-as-is, or removed from scope.
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/README.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/README.md
@@ -7,7 +7,7 @@ A Claude Code plugin that ships **23 model-invokable skills** for connecting Ora
 
 **v0.5.0** adds 5 new connectors (Oracle Database, PeopleSoft, Siebel, Salesforce, Hive) plus the new pushdown.sql / catalog.id / manifest.path patterns from [oracle-samples/oracle-aidp-samples PR #46](https://github.com/oracle-samples/oracle-aidp-samples/pull/46).
 
-**Live-validated** on the workbench `tpcds` cluster (Spark 3.5.0): **17 PASS / 4 ship-as-is** out of 21 test rows in v0.4.x. The 5 new v0.5.0 connectors ship as-is — they wrap the same `aidataplatform` format handler validated upstream by the oracle-samples team. See [`tests/live-results/RESULTS.md`](tests/live-results/RESULTS.md).
+All connectors wrap the official AIDP `aidataplatform` Spark format handler (or, where applicable, Spark JDBC / structured streaming / `oci://`/`s3a://`/`abfss://`) — same patterns shown in the upstream [`oracle-samples/oracle-aidp-samples`](https://github.com/oracle-samples/oracle-aidp-samples) connector notebooks.
 
 ## Install
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/README.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/README.md
@@ -1,8 +1,13 @@
 # Oracle AI Data Platform Workbench — Spark Connectors
 
-A Claude Code plugin that ships **18 model-invokable skills** for connecting Oracle AI Data Platform Workbench Spark notebooks to every data source these notebooks commonly need. Each skill produces plain Python (Spark JDBC, Spark structured streaming, Spark `oci://`/`s3a://`/`abfss://`, or REST → Spark DataFrame) that runs in the notebook without any additional runtime.
+> **Canonical home:** [`oracle-samples/oracle-aidp-samples/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors`](https://github.com/oracle-samples/oracle-aidp-samples/tree/main/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors).
+> This repository is now a personal development mirror. End users should install via Anthropic's community marketplace (see below), which sources from the canonical Oracle-org location.
 
-**Live-validated** on the workbench `tpcds` cluster (Spark 3.5.0): **17 PASS / 4 ship-as-is** out of 21 test rows. See [`tests/live-results/RESULTS.md`](tests/live-results/RESULTS.md).
+A Claude Code plugin that ships **23 model-invokable skills** for connecting Oracle AI Data Platform Workbench Spark notebooks to every data source these notebooks commonly need. Each skill produces plain Python (Spark JDBC, Spark structured streaming, Spark `oci://`/`s3a://`/`abfss://`, or REST → Spark DataFrame) that runs in the notebook without any additional runtime.
+
+**v0.5.0** adds 5 new connectors (Oracle Database, PeopleSoft, Siebel, Salesforce, Hive) plus the new pushdown.sql / catalog.id / manifest.path patterns from [oracle-samples/oracle-aidp-samples PR #46](https://github.com/oracle-samples/oracle-aidp-samples/pull/46).
+
+**Live-validated** on the workbench `tpcds` cluster (Spark 3.5.0): **17 PASS / 4 ship-as-is** out of 21 test rows in v0.4.x. The 5 new v0.5.0 connectors ship as-is — they wrap the same `aidataplatform` format handler validated upstream by the oracle-samples team. See [`tests/live-results/RESULTS.md`](tests/live-results/RESULTS.md).
 
 ## Install
 
@@ -13,21 +18,27 @@ From Anthropic's community plugin marketplace (recommended):
 /plugin install oracle-ai-data-platform-workbench-spark-connectors
 ```
 
-This is the canonical home. The plugin lives at
-[`oracle-samples/oracle-aidp-samples/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors`](https://github.com/oracle-samples/oracle-aidp-samples/tree/main/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors)
-and the community marketplace points at this subdirectory via `git-subdir` source.
+Or from this development mirror (gets the latest pre-release commits):
+
+```
+/plugin marketplace add ahmedawan-oracle/claude-code-plugins
+/plugin install oracle-ai-data-platform-workbench-spark-connectors@aidp-connectors
+```
 
 ## What's in here
 
-20 skills total (18 connectors + 1 bootstrap + 1 routing).
+25 skills total (23 connectors + 1 bootstrap + 1 routing).
 
 ### Oracle / OCI sources
 | Skill | Target | Transport | Recommended auth |
 |---|---|---|---|
 | `aidp-connectors-overview` | (router) | — | — |
 | `aidp-connectors-bootstrap` | one-time setup | — | — |
-| `aidp-alh` | Oracle DB family (Autonomous: ALH/ADW/ATP + non-Autonomous: Compute/Base DB/on-prem) | Spark JDBC | Wallet (mTLS) for Autonomous, plain user/password for non-Autonomous |
+| `aidp-alh` | Oracle Autonomous DB family (ALH / ADW / ATP) | Spark JDBC | Wallet (mTLS), IAM DB-Token, or API key |
+| `aidp-oracle-db` ⭐ NEW | Generic Oracle DB (Compute / Base DB / on-prem / 19c-26ai non-Autonomous) | `aidataplatform` (`type=ORACLE_DB`) | Plain user/password |
 | `aidp-exacs` | Exadata Cloud Service | Spark JDBC (TCP 1521 + NNE AES256) | Plain user/password |
+| `aidp-peoplesoft` ⭐ NEW | Oracle PeopleSoft | `aidataplatform` (`type=ORACLE_PEOPLESOFT`) | Plain user/password (read-only) |
+| `aidp-siebel` ⭐ NEW | Oracle Siebel CRM | `aidataplatform` (`type=ORACLE_SIEBEL`) | Plain user/password (read-only) |
 | `aidp-fusion-rest` | Fusion ERP/HCM/SCM | REST → DataFrame | HTTP Basic |
 | `aidp-fusion-bicc` | Fusion BICC bulk extracts | `aidataplatform` (`type=FUSION_BICC`) | HTTP Basic |
 | `aidp-epm-cloud` | EPM Cloud Planning | REST → DataFrame | HTTP Basic (`tenancy.user@domain`) |
@@ -36,12 +47,18 @@ and the community marketplace points at this subdirectory via `git-subdir` sourc
 | `aidp-object-storage` | OCI Object Storage native | Spark `oci://` | Implicit IAM (workspace identity) |
 | `aidp-iceberg` | Apache Iceberg on OCI Object Storage | Iceberg Hadoop catalog on `oci://` | Implicit IAM |
 
-### External RDBMS (`aidataplatform` format)
+### External RDBMS / Hadoop (`aidataplatform` format)
 | Skill | Target | Transport | Recommended auth |
 |---|---|---|---|
 | `aidp-postgresql` | PostgreSQL | Spark JDBC (runtime-loaded driver) for SSL targets, `aidataplatform` `type=POSTGRESQL` for non-SSL | Plain user/password |
 | `aidp-mysql` | MySQL / OCI MySQL HeatWave | `aidataplatform` (`type=MYSQL` or `MYSQL_HEATWAVE`) | Plain user/password |
 | `aidp-sqlserver` | Microsoft SQL Server / Azure SQL DB | `aidataplatform` (`type=SQLSERVER`) | Plain user/password |
+| `aidp-hive` ⭐ NEW | Apache Hive (HiveServer2, non-Kerberos) | `aidataplatform` (`type=HIVE`) | Plain user/password |
+
+### SaaS
+| Skill | Target | Transport | Recommended auth |
+|---|---|---|---|
+| `aidp-salesforce` ⭐ NEW | Salesforce (Sales/Service Cloud, custom sObjects) | `aidataplatform` (`type=SFORCE`) | Username + password+security-token (read-only) |
 
 ### Multi-cloud + escape hatches
 | Skill | Target | Transport | Recommended auth |
@@ -49,9 +66,19 @@ and the community marketplace points at this subdirectory via `git-subdir` sourc
 | `aidp-snowflake` | Snowflake | `format("snowflake")` (Snowflake Spark connector) | sfUser/sfPassword |
 | `aidp-azure-adls` | Azure ADLS Gen2 | Spark `abfss://` | OAuth client-credentials (Service Principal) |
 | `aidp-aws-s3` | AWS S3 | Spark `s3a://` (runtime-loaded `hadoop-aws` + `aws-java-sdk-bundle`) | AWS access keys |
-| `aidp-rest-generic` | Any REST API with a manifest | `aidataplatform` (`type=GENERIC_REST`) | HTTP Basic |
+| `aidp-rest-generic` | Any REST API with a manifest URL or Volume `manifest.path` | `aidataplatform` (`type=GENERIC_REST`) | HTTP Basic |
 | `aidp-jdbc-custom` | Any DB with a JDBC driver | Spark `format("jdbc")` (runtime-loaded driver) | Driver-specific |
 | `aidp-excel` | `.xlsx` files in Volumes / Object Storage | stdlib `zipfile` + XML parser (no extra deps) | None (file-based) |
+
+### v0.5.0 cross-cutting patterns
+
+The new oracle-samples PR #46 introduced three patterns that are wired into every applicable skill:
+
+| Pattern | What it does |
+|---|---|
+| `pushdown.sql` | Push a complete source SQL query at the database — replaces schema/table option building. Useful for joins, filters, derived columns, and bulk-table avoidance. |
+| `catalog.id` | Reference an existing AIDP external catalog connection by id — drops host/port/user/password from the option list. Pairs with three-part `spark.table()` / `saveAsTable()` for the cleanest read/write code. |
+| `manifest.path` | (REST only) Reference a manifest file by workspace/Volume path instead of HTTP URL. Lets manifests be hand-authored and version-pinned alongside the notebook. |
 
 ## How to use
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/hive_read_write.ipynb
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/hive_read_write.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright © 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Hive Connector Samples\n\nRead/write ingestion samples for the `HIVE` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nReplace placeholders such as `<HOST>`, `<USERNAME>`, `<PASSWORD>`, `<SCHEMA>`, and `<TABLE_NAME>` with values from your environment before running the notebook.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Read from Hive\nhive_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"HIVE\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .load()\n\nhive_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Write Sample\n\nThe write sample uses `CREATE`; switch `write.mode` to `APPEND` or `OVERWRITE` when that matches the target behavior.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Write to Hive\nhive_df.write.format(\"aidataplatform\") \\\n    .option(\"type\", \"HIVE\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TARGET_TABLE_NAME>\") \\\n    .option(\"write.mode\", \"CREATE\") \\\n    .save()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Full SQL pushdown for Hive\nhive_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"HIVE\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\nhive_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | `HIVE` | Y | Data source type. |\n| `host` | Valid hostname or IP | Y | Hive host. |\n| `port` | Valid port number | Y | Hive port. |\n| `database.name` | Database name | N | Optional database name when needed. |\n| `authentication.method` | `basic`, `kerberos` | N | Authentication method. If omitted, the connector attempts a non-explicit auth flow. |\n| `user.name` | Valid username | Y for basic, N for some Kerberos flows | Username used for connectivity. |\n| `password` | Valid password | Y for basic, N for some Kerberos flows | Password used for connectivity. |\n| `service.principal.name` | Kerberos principal name | Y for Kerberos | Service principal name for Kerberos authentication. |\n| `key.tab.content` | Keytab content | Y for Kerberos | Keytab content used for Kerberos authentication. |\n| `key.distribution.center` | Valid hostname or IP | Y for Kerberos | KDC host used for Kerberos authentication. |\n| `schema` | Valid schema name | Y | Schema to read from or write to. |\n| `table` | Valid table name | Y for table access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema. |\n| `sql` | Valid SQL query | N | Custom SQL query for reads. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads or writes. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `write.mode` | `CREATE`, `APPEND`, `OVERWRITE` | Y during write | Write mode to use. |\n| `write.empty.value.as.null` | `true`, `false` | N | Convert empty incoming string values to null before writing. |\n| `write.batch.size` | Positive integer | N | Number of rows written in a batch. |\n| `write.reject.limit` | Non-negative integer | N | Maximum rejected-row threshold before the write fails. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Hive Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/oracle_db_read_write.ipynb
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/oracle_db_read_write.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright © 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Oracle Database Connector Samples\n\nRead/write ingestion and external-catalog samples for the `ORACLE_DB` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Samples\n\nUse inline connector options when you want the notebook to carry all connection properties explicitly.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Ingestion-style read using inline connector options\noracle_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"1521\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .load()\n\noracle_df.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Ingestion-style write using inline connector options\noracle_df.write.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"1521\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TARGET_TABLE_NAME>\") \\\n    .option(\"write.mode\", \"APPEND\") \\\n    .save()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Samples Using `catalog.id`\n\nUse `catalog.id` to reuse an existing external catalog connection and avoid placing credentials directly in the notebook.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Ingestion-style read using an existing external catalog connection\noracle_df_catalog = spark.read.format(\"aidataplatform\") \\\n    .option(\"catalog.id\", \"<CATALOG_ID>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .load()\n\noracle_df_catalog.show()\n\n# Ingestion-style write using an existing external catalog connection\noracle_df.write.format(\"aidataplatform\") \\\n    .option(\"catalog.id\", \"<CATALOG_ID>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TARGET_TABLE_NAME>\") \\\n    .option(\"write.mode\", \"APPEND\") \\\n    .save()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## External Catalog Samples\n\nAfter creating an external catalog in Master Catalogs, use three-part names in the form `<CATALOG_ID>.<SCHEMA>.<TABLE_NAME>` for Spark table access.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# External catalog read with three-part name\ncatalog_df = spark.table(\"<CATALOG_ID>.<SCHEMA>.<TABLE_NAME>\")\ncatalog_df.show()\n\n# External catalog write - create\ncatalog_df.write.saveAsTable(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n\n# External catalog write - overwrite\ncatalog_df.write.mode(\"overwrite\").saveAsTable(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n\n# External catalog write - append\ncatalog_df.write.mode(\"append\").insertInto(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n\n# External catalog write - merge\ncatalog_df.write     .option(\"write.mode\", \"MERGE\")     .option(\"write.merge.keys\", \"<KEY_COLUMN>\")     .insertInto(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown Samples\n\nUse these samples when the source should execute filters or full SQL instead of Spark reading the full table first.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Auto pushdown from DataFrame operations\noracle_df_filtered = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"1521\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .option(\"row.limit\", \"1000\") \\\n    .load() \\\n    .select(\"<COLUMN_1>\", \"<COLUMN_2>\") \\\n    .filter(\"<COLUMN_1> = '<VALUE>'\")\n\noracle_df_filtered.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Oracle SQL pushdown using inline connector options\noracle_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"1521\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Oracle SQL pushdown using an external catalog connection\noracle_df_catalog_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"catalog.id\", \"<CATALOG_ID>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_df_catalog_pushdown.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# External catalog pushdown through Spark DataFrame operations\ncatalog_df = spark.read.table(\"<CATALOG_ID>.<SCHEMA>.<TABLE_NAME>\")\n\ncatalog_df     .select(\"<COLUMN_1>\", \"<COLUMN_2>\")     .filter(\"<COLUMN_1> = '<VALUE>'\")     .orderBy(\"<COLUMN_2>\")     .limit(100)     .show()\n\n# Aggregate pushdown is supported for external catalog reads where Spark delegates it.\ncatalog_df.groupBy(\"<COLUMN_1>\").count().show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | `ORACLE_DB` | Y for inline connector config | Data source type. |\n| `catalog.id` | Existing external catalog identifier | N | Reuse the connection details from an already created external catalog instead of passing the connector connection properties inline. |\n| `host` | Valid hostname or IP | Y | Database host. |\n| `port` | Valid port number | Y | Database listener port. |\n| `database.name` | Oracle service name | Y, if `database.sid` is not passed | Oracle service name. |\n| `database.sid` | Oracle SID | Y, if `database.name` is not passed | Oracle SID. |\n| `ssl.enabled` | `true`, `false` | N | Enable SSL or TLS-based Oracle connectivity. |\n| `rac.enabled` | `true`, `false` | N | Enable RAC-aware Oracle connectivity. |\n| `wallet.content` | Base64-encoded wallet content | N | Optional wallet content for wallet-based connectivity. |\n| `wallet.path` | `/Workspace/<path>` or `/Volumes/<path>` | N | Optional wallet path for wallet-based connectivity. |\n| `wallet.password` | Wallet password | N | Optional wallet password. |\n| `user.name` | Valid DB user | Y | Login user used for connectivity. |\n| `password` | Valid DB password | Y | Password for `user.name`. |\n| `oracle.user.name.quoted` | `true`, `false` | N | Use this when the Oracle login user itself was created as a quoted mixed-case or lower-case username. |\n| `schema` | Valid schema name | Y | Schema to read from or write to. |\n| `table` | Valid table name | Y for table-based access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema when reading through a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for read scenarios. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads or writes. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use for range partitioning. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `source.projection.pushdown.disabled` | `true`, `false` | N | Disable projection pushdown for external-catalog reads. |\n| `source.filter.pushdown.disabled` | `true`, `false` | N | Disable filter pushdown for external-catalog reads. |\n| `source.topn.pushdown.disabled` | `true`, `false` | N | Disable TopN pushdown for external-catalog reads. |\n| `source.aggregation.pushdown.disabled` | `true`, `false` | N | Disable aggregation pushdown for external-catalog reads. |\n| `source.limit.pushdown.disabled` | `true`, `false` | N | Disable limit pushdown for external-catalog reads. |\n| `source.offset.pushdown.disabled` | `true`, `false` | N | Disable offset pushdown for external-catalog reads. |\n| `write.mode` | `CREATE`, `APPEND`, `OVERWRITE`, `MERGE` | Y during write | Write mode to use. This is primarily used for ingestion samples; refer to the sample code above for external catalog write examples. |\n| `write.empty.value.as.null` | `true`, `false` | N | Convert empty incoming string values to null before writing. |\n| `write.batch.size` | Positive integer | N | Number of rows written in a batch. |\n| `write.reject.limit` | Non-negative integer | N | Maximum rejected-row threshold before the write fails. |\n| `write.merge.keys` | Comma-separated column names | Y for `MERGE` | Key columns used in the `MERGE` condition. |\n| `merge.matched.where` | SQL condition using `tgt` and `src` aliases | N | Additional filter applied to rows where the `MERGE` match condition succeeds. |\n| `merge.matched.delete` | SQL condition using `tgt` and `src` aliases | N | Delete matching target rows when the given condition evaluates to true. |\n| `merge.not.matched.where` | SQL condition using `tgt` and `src` aliases | N | Additional filter applied before inserting rows that do not match. |\n| `merge.staging.using.username` | `true`, `false` | N | For `MERGE`, stage the temporary merge table in the login user's schema from `user.name` instead of the default target schema. |\n| `overwrite.with.recreate` | `true`, `false` | N | Controls overwrite behavior when the target shape is incompatible and overwrite needs a drop-and-recreate. |\n| `oracle.write.native.boolean` | `true`, `false` | N | Write Spark boolean columns as native Oracle `BOOLEAN` when the target Oracle version supports it. Leave it unset to keep the backward-compatible non-native path. |\n| `oracle.append.hint.enabled` | `true`, `false` | N | For append writes, request Oracle append-insert behavior when you want the target write path to honor the append hint. |\n| `preserve.oracle.column.types` | Comma-separated column/type mappings such as `EMBEDDING VECTOR(512, FLOAT32)`, `DOC JSON`, `RAW_PAYLOAD RAW(16)` | N | Create-only Oracle option to preserve Oracle-native target types during table creation instead of falling back to generic mapped types. Use this when the new table must keep special Oracle types such as `VECTOR`, `JSON`, or `RAW`. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Oracle Database Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/peoplesoft_read.ipynb
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/peoplesoft_read.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright © 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Oracle PeopleSoft Connector Samples\n\nRead-only ingestion samples for the `ORACLE_PEOPLESOFT` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nReplace placeholders such as `<HOST>`, `<USERNAME>`, `<PASSWORD>`, `<SCHEMA>`, and `<TABLE_NAME>` with values from your environment before running the notebook.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Read from Oracle PeopleSoft\noracle_peoplesoft_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_PEOPLESOFT\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .load()\n\noracle_peoplesoft_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Full SQL pushdown for Oracle PeopleSoft\noracle_peoplesoft_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_PEOPLESOFT\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_peoplesoft_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | Connector type shown in the sample | Y | Data source type. |\n| `host` | Valid hostname or IP address | Y | Source host. |\n| `port` | Valid port number | Y | Source port. |\n| `database.name` | Database or service name | N | Database name when the connector requires one. |\n| `user.name` | Valid source username | Y | Login user used for connectivity. |\n| `password` | Valid source password | Y | Password for `user.name`. |\n| `schema` | Valid schema name | Y | Schema to read from. |\n| `table` | Valid table name | Y for table-based access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema when reading through a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for read scenarios. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Oracle PeopleSoft Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/salesforce_read.ipynb
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/salesforce_read.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright © 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Salesforce Connector Samples\n\nRead-only ingestion samples for the `SFORCE` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nReplace placeholders such as `<HOST>`, `<USERNAME>`, `<PASSWORD>`, `<SCHEMA>`, and `<TABLE_NAME>` with values from your environment before running the notebook.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Read from Salesforce\nsalesforce_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"SFORCE\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .load()\n\nsalesforce_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Full SQL pushdown for Salesforce\nsalesforce_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"SFORCE\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\nsalesforce_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | `SFORCE` | Y | Data source type. |\n| `host` | Valid Salesforce JDBC host or endpoint | Y | Salesforce endpoint host. |\n| `port` | Valid port number | Y | Network port used by the Salesforce JDBC endpoint. |\n| `database.name` | Optional Salesforce database or catalog name exposed by the driver | N | Optional logical database name when the Salesforce JDBC configuration expects it. |\n| `user.name` | Valid Salesforce username | Y | Username used for Salesforce connectivity. |\n| `password` | Valid Salesforce password or security-token-appended password, depending on the configured endpoint | Y | Password used for Salesforce connectivity. |\n| `schema` | Valid schema name | Y | Schema exposed by the Salesforce JDBC driver. |\n| `table` | Valid object or table name | Y for table access | Salesforce object name to read. |\n| `view` | Valid view name | N | View name when the driver exposes the target object as a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for reads. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use for reads. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Salesforce Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/siebel_read.ipynb
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/examples/siebel_read.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright © 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Oracle Siebel Connector Samples\n\nRead-only ingestion samples for the `ORACLE_SIEBEL` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nReplace placeholders such as `<HOST>`, `<USERNAME>`, `<PASSWORD>`, `<SCHEMA>`, and `<TABLE_NAME>` with values from your environment before running the notebook.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Read from Oracle Siebel\noracle_siebel_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_SIEBEL\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"schema\", \"<SCHEMA>\") \\\n    .option(\"table\", \"<TABLE_NAME>\") \\\n    .load()\n\noracle_siebel_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Full SQL pushdown for Oracle Siebel\noracle_siebel_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_SIEBEL\") \\\n    .option(\"host\", \"<HOST>\") \\\n    .option(\"port\", \"<PORT>\") \\\n    .option(\"database.name\", \"<DATABASE_NAME>\") \\\n    .option(\"user.name\", \"<USERNAME>\") \\\n    .option(\"password\", \"<PASSWORD>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_siebel_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | Connector type shown in the sample | Y | Data source type. |\n| `host` | Valid hostname or IP address | Y | Source host. |\n| `port` | Valid port number | Y | Source port. |\n| `database.name` | Database or service name | N | Database name when the connector requires one. |\n| `user.name` | Valid source username | Y | Login user used for connectivity. |\n| `password` | Valid source password | Y | Password for `user.name`. |\n| `schema` | Valid schema name | Y | Schema to read from. |\n| `table` | Valid table name | Y for table-based access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema when reading through a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for read scenarios. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Oracle Siebel Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/scripts/oracle_ai_data_platform_connectors/aidataplatform.py
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/scripts/oracle_ai_data_platform_connectors/aidataplatform.py
@@ -8,22 +8,38 @@ across many connector types — host/port/user/password/schema/table — only
 Connector types known to be supported by the format handler (from the official
 oracle-aidp-samples repo):
 
-* ``ORACLE_DB``       — Oracle DB on Compute / on-prem / Base DB
-* ``ORACLE_EXADATA``  — Exadata Cloud Service
-* ``ORACLE_ALH``      — Autonomous Data Warehouse / Lakehouse
-* ``ORACLE_ATP``      — Autonomous Transaction Processing
-* ``POSTGRESQL``      — PostgreSQL
-* ``MYSQL``           — MySQL
-* ``MYSQL_HEATWAVE``  — OCI MySQL HeatWave
-* ``SQLSERVER``       — Microsoft SQL Server
-* ``KAFKA``           — Kafka via the format-handler shape
-* ``FUSION_BICC``     — Fusion BICC bulk extracts
-* ``GENERIC_REST``    — any REST API with a manifest
+* ``ORACLE_DB``          — Oracle DB on Compute / on-prem / Base DB
+* ``ORACLE_EXADATA``     — Exadata Cloud Service
+* ``ORACLE_ALH``         — Autonomous Data Warehouse / Lakehouse
+* ``ORACLE_ATP``         — Autonomous Transaction Processing
+* ``ORACLE_PEOPLESOFT``  — Oracle PeopleSoft (read-only)
+* ``ORACLE_SIEBEL``      — Oracle Siebel CRM (read-only)
+* ``SFORCE``             — Salesforce (read-only)
+* ``HIVE``               — Apache Hive (read-write, non-Kerberos)
+* ``POSTGRESQL``         — PostgreSQL
+* ``MYSQL``              — MySQL
+* ``MYSQL_HEATWAVE``     — OCI MySQL HeatWave
+* ``SQLSERVER``          — Microsoft SQL Server
+* ``KAFKA``              — Kafka via the format-handler shape
+* ``FUSION_BICC``        — Fusion BICC bulk extracts
+* ``GENERIC_REST``       — any REST API with a manifest
 
 This module exposes one canonical builder, ``aidataplatform_options()``, that
 takes the common keys and lets caller-specific extras flow through. Skills
 that wrap a particular ``type`` should compose this helper rather than
 re-declaring the option dict.
+
+Common ``extra`` options seen across multiple types (added in oracle-samples
+PR #46):
+
+* ``write.mode``       — ``CREATE`` | ``APPEND`` | ``OVERWRITE`` | ``MERGE``
+* ``write.merge.keys`` — comma-separated key columns (when ``write.mode=MERGE``)
+* ``pushdown.sql``     — full SQL pushed at the source instead of
+                         host/schema/table option building
+* ``catalog.id``       — reference an existing AIDP external catalog by id
+                         (replaces host/port/user/password)
+* ``manifest.path``    — workspace/volume path to a REST manifest file
+                         (alternative to ``manifest.url``)
 """
 
 from __future__ import annotations

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/scripts/oracle_ai_data_platform_connectors/excel.py
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/scripts/oracle_ai_data_platform_connectors/excel.py
@@ -9,8 +9,8 @@ Crealytics dependency closure is large).
 This module is a third path: parse the .xlsx with stdlib ``zipfile`` +
 ``xml.etree.ElementTree``. .xlsx is a ZIP of XML files; sharedStrings.xml +
 worksheets/sheet1.xml together carry the cell data we need for read-only
-ingestion. Live-validated on the AIDP `tpcds` cluster — 5,460-byte file
-parsed in ~120 ms with no extra deps.
+ingestion. No extra deps — works on any AIDP cluster regardless of PyPI /
+Maven access.
 
 Limitations:
 * Read-only. There's no stdlib path to write .xlsx without ``openpyxl`` or

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/runtime_load.py
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/runtime_load.py
@@ -26,9 +26,9 @@ Use ``add_spark_connector_at_runtime`` for Spark DataSource JARs (Snowflake,
 spark-excel, custom format providers). Use ``add_jdbc_jar_at_runtime`` for
 plain JDBC drivers (SQLite, ClickHouse, DuckDB, IBM DB2 ...).
 
-Live-validated on the AIDP ``tpcds`` cluster (Spark 3.5.0):
-* SQLite JDBC (no executor distribution needed — driver-only path).
-* Snowflake Spark connector (needs both driver and executor distribution).
+Two patterns covered:
+* SQLite JDBC and similar (no executor distribution needed — driver-only).
+* Snowflake-style Spark connectors (needs both driver and executor distribution).
 
 Maven Central is reachable from AIDP clusters; PyPI is not.
 """

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-connectors-overview/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-connectors-overview/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Help the user pick the right connector skill for their data source from an AIDP notebook. Use as a router when the user mentions multiple sources, isn't sure which connector applies, or asks "how do I connect to X from AIDP". Covers Oracle and non-Oracle sources — Postgres, MySQL, SQL Server, Snowflake, S3, ADLS, Iceberg, Object Storage, generic JDBC, Excel.
+description: Help the user pick the right connector skill for their data source from an AIDP notebook. Use as a router when the user mentions multiple sources, isn't sure which connector applies, or asks "how do I connect to X from AIDP". Covers 23 data sources — Oracle Autonomous DB family (ALH/ADW/ATP), generic Oracle DB, ExaCS, PeopleSoft, Siebel, Fusion ERP/BICC, EPM Cloud, Essbase, OCI Streaming, Object Storage, Iceberg, plus PostgreSQL, MySQL/HeatWave, SQL Server, Hive, Snowflake, Azure ADLS, AWS S3, Salesforce, generic REST, custom JDBC, Excel.
 allowed-tools: Read
 ---
 
@@ -23,8 +23,11 @@ Otherwise, pick the right skill from this table and **invoke that skill**. Don't
 
 | User says... | Use skill |
 |---|---|
-| "ALH", "AI Lakehouse", "ADW", "ATP", "Autonomous Database", "26ai", "external catalog from lakehouse", "Oracle on Compute", "Base DB", "on-prem Oracle", "Oracle 19c / 21c" | [`aidp-alh`](../aidp-alh/SKILL.md) — covers the entire Oracle DB family (Autonomous + non-Autonomous) |
+| "ALH", "AI Lakehouse", "ADW", "ATP", "Autonomous Database", "26ai" | [`aidp-alh`](../aidp-alh/SKILL.md) — Autonomous DB family (wallet / IAM DB-Token / API key) |
+| "Oracle Database", "generic Oracle DB", "on-prem Oracle", "Oracle 19c / 21c", "Base DB", "Oracle on Compute", non-Autonomous Oracle | [`aidp-oracle-db`](../aidp-oracle-db/SKILL.md) — generic Oracle DB via plain user/password on TCP 1521 |
 | "ExaCS", "Exadata", "Exadata Cloud", "private-subnet Oracle DB" | [`aidp-exacs`](../aidp-exacs/SKILL.md) |
+| "PeopleSoft", "PSFT", "PS HCM", "FSCM", "Campus Solutions" | [`aidp-peoplesoft`](../aidp-peoplesoft/SKILL.md) |
+| "Siebel", "Siebel CRM", "S_CONTACT", "S_ORG_EXT" | [`aidp-siebel`](../aidp-siebel/SKILL.md) |
 | "Fusion ERP", "Fusion HCM", "Fusion REST", "FA REST", "Cloud ERP API" | [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md) |
 | "BICC", "BI Cloud Connector", "Fusion bulk extract", >50k rows from Fusion | [`aidp-fusion-bicc`](../aidp-fusion-bicc/SKILL.md) |
 | "EPM Cloud", "EPBCS", "Hyperion Planning", "Planning app", "exportdataslice" | [`aidp-epm-cloud`](../aidp-epm-cloud/SKILL.md) |
@@ -33,13 +36,20 @@ Otherwise, pick the right skill from this table and **invoke that skill**. Don't
 | "OCI Object Storage", "oci://", "external volume", "external table on bucket" | [`aidp-object-storage`](../aidp-object-storage/SKILL.md) |
 | "Iceberg", "Apache Iceberg", "time travel", "snapshots", "schema evolution" | [`aidp-iceberg`](../aidp-iceberg/SKILL.md) |
 
-### External RDBMS (non-Oracle)
+### External RDBMS / Hadoop (non-Oracle)
 
 | User says... | Use skill |
 |---|---|
 | "PostgreSQL", "Postgres", "psql" | [`aidp-postgresql`](../aidp-postgresql/SKILL.md) |
 | "MySQL", "HeatWave", "MDS", "MySQL Database Service" | [`aidp-mysql`](../aidp-mysql/SKILL.md) |
 | "SQL Server", "MSSQL", "Azure SQL", "TDS" | [`aidp-sqlserver`](../aidp-sqlserver/SKILL.md) |
+| "Hive", "HiveServer2", "HS2", "HCatalog", non-Kerberos Hive | [`aidp-hive`](../aidp-hive/SKILL.md) |
+
+### SaaS
+
+| User says... | Use skill |
+|---|---|
+| "Salesforce", "SFDC", "Sales Cloud", "Service Cloud", "sObject", "SOQL", "Account / Opportunity / Lead" | [`aidp-salesforce`](../aidp-salesforce/SKILL.md) |
 
 ### Multi-cloud + escape hatches
 
@@ -48,7 +58,7 @@ Otherwise, pick the right skill from this table and **invoke that skill**. Don't
 | "Snowflake", "sfUrl", "sfWarehouse" | [`aidp-snowflake`](../aidp-snowflake/SKILL.md) |
 | "ADLS", "Azure Data Lake", "abfss" | [`aidp-azure-adls`](../aidp-azure-adls/SKILL.md) |
 | "S3", "AWS S3", "s3a" | [`aidp-aws-s3`](../aidp-aws-s3/SKILL.md) |
-| "Generic REST", "manifest URL", REST endpoint with manifest schema | [`aidp-rest-generic`](../aidp-rest-generic/SKILL.md) |
+| "Generic REST", "manifest URL", "manifest.path", REST endpoint with manifest schema | [`aidp-rest-generic`](../aidp-rest-generic/SKILL.md) |
 | "Custom JDBC", "ClickHouse", "DuckDB", "DB2", "SAP HANA", any DB without a dedicated skill | [`aidp-jdbc-custom`](../aidp-jdbc-custom/SKILL.md) |
 | ".xlsx", "Excel", "spreadsheet ingestion" | [`aidp-excel`](../aidp-excel/SKILL.md) |
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-excel/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-excel/SKILL.md
@@ -14,9 +14,9 @@ Two ways to land Excel data in Spark: the native Spark Excel format (faster, par
 ## When NOT to use
 - For CSV files → just use [`aidp-object-storage`](../aidp-object-storage/SKILL.md). Spark reads CSV natively.
 
-## Option C — Pure-stdlib parser (no openpyxl, no JARs) ★ live-validated
+## Option C — Pure-stdlib parser (no openpyxl, no JARs)
 
-The plugin ships a stdlib-only `.xlsx` reader. **No** `openpyxl`. **No** Crealytics JAR. Works on AIDP clusters that have neither PyPI access nor Maven access for the Crealytics dependency closure. Live-validated on the AIDP `tpcds` cluster — 5,460-byte file parsed in ~120 ms.
+The plugin ships a stdlib-only `.xlsx` reader. **No** `openpyxl`. **No** Crealytics JAR. Works on AIDP clusters that have neither PyPI access nor Maven access for the Crealytics dependency closure.
 
 ```python
 import os

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-hive/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-hive/SKILL.md
@@ -1,0 +1,94 @@
+---
+description: Read or write Apache Hive from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Hive, HiveServer2, HS2, HCatalog, or has a Hive metastore host/port. Auth is host/port + user/password. Read-write.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# `aidp-hive` — Apache Hive via AIDP `aidataplatform`
+
+## When to use
+- User wants to read or write a Hive table from an AIDP notebook.
+- User mentions: "Hive", "HiveServer2", "HS2", "HCatalog", "Hive metastore", a Hive database/table name.
+
+## When NOT to use
+- For Oracle Big Data Service (BDS) HiveServer2 with **Kerberos** auth via Spark JDBC → use a custom skill (we removed `aidp-bds-hive` from v0.4 scope; revisit if your customer needs Kerberos specifically). The current `aidp-hive` skill covers non-Kerberos Hive (LDAP / SASL-PLAIN / NoAuth) via the `aidataplatform` format handler.
+- For Iceberg-on-Hive-style metadata where data lives on `oci://` → [`aidp-iceberg`](../aidp-iceberg/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Network: cluster must reach the HS2 host on the configured port (typically 10000). If your Hive lives in a customer VCN, ensure VCN peering is in place — the cluster pod CIDR has no implicit route to user VCNs.
+3. Env vars / OCI Vault secrets:
+   - `HIVE_HOST` (HiveServer2 hostname)
+   - `HIVE_PORT` (typically `10000`)
+   - `HIVE_USER`, `HIVE_PASSWORD`
+   - `HIVE_SCHEMA` (Hive database name)
+   - `HIVE_TABLE` (Hive table name)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="HIVE",
+    host=os.environ["HIVE_HOST"],
+    port=int(os.environ.get("HIVE_PORT", "10000")),
+    user=os.environ["HIVE_USER"],
+    password=os.environ["HIVE_PASSWORD"],
+    schema=os.environ["HIVE_SCHEMA"],
+    table=os.environ["HIVE_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Write
+
+```python
+opts = aidataplatform_options(
+    type="HIVE",
+    host=os.environ["HIVE_HOST"],
+    port=int(os.environ.get("HIVE_PORT", "10000")),
+    user=os.environ["HIVE_USER"],
+    password=os.environ["HIVE_PASSWORD"],
+    schema=os.environ["HIVE_SCHEMA"],
+    table=os.environ["HIVE_TARGET_TABLE"],
+    extra={"write.mode": "APPEND"},   # CREATE | APPEND | OVERWRITE
+)
+df.write.format(AIDP_FORMAT).options(**opts).save()
+```
+
+## Pushdown SQL
+
+```python
+opts = aidataplatform_options(
+    type="HIVE",
+    host=os.environ["HIVE_HOST"],
+    port=int(os.environ.get("HIVE_PORT", "10000")),
+    user=os.environ["HIVE_USER"],
+    password=os.environ["HIVE_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT customer_id, SUM(amount) AS total "
+            "FROM sales_db.transactions "
+            "WHERE event_dt >= '2025-01-01' "
+            "GROUP BY customer_id"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Gotchas
+- **No `database.name` option** — Hive uses `schema` directly to identify the Hive database (e.g. `default`, `sales_db`). Don't pass `database_name`.
+- **Network reachability is the most common failure.** Smoke-test from the cluster: `socket.create_connection((host, port), timeout=8)`. If this fails, it's a network problem, not an auth problem — VCN peering / NSG / DNS, in that order.
+- **No Kerberos on this skill.** This connector handler uses LDAP / SASL-PLAIN / NoAuth. If your Hive cluster only accepts Kerberos, you need a Spark-native JDBC path with a keytab (out of scope for v0.5 — file an issue).
+- **Write modes** — `CREATE` (fail if exists), `APPEND`, `OVERWRITE`. Default is `CREATE`.
+- **Partitioned tables.** When writing to a partitioned Hive table, `OVERWRITE` overwrites all partitions touched by the DataFrame's distinct partition keys; existing partitions not touched are preserved.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples → `data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors/Hive.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors/Hive.ipynb)

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-jdbc-custom/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-jdbc-custom/SKILL.md
@@ -18,9 +18,9 @@ The catch-all skill for any DB with a JDBC driver. Skips the AIDP `aidataplatfor
 
 ## Two ways to load a non-bundled JDBC driver
 
-### Option A — Runtime-load (recommended; no cluster restart) ★ live-validated
+### Option A — Runtime-load (recommended; no cluster restart)
 
-The plugin ships a helper that loads a JDBC JAR into a running Spark session via Java's URLClassLoader + DriverManager. It works without admin access and without restarting the kernel. Live-validated on the AIDP `tpcds` cluster (Spark 3.5.0) — see `tests/live-results/row24.json`.
+The plugin ships a helper that loads a JDBC JAR into a running Spark session via Java's URLClassLoader + DriverManager. It works without admin access and without restarting the kernel.
 
 ```python
 import os

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-oracle-db/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-oracle-db/SKILL.md
@@ -1,0 +1,125 @@
+---
+description: Read or write an Oracle Database (Compute / Base DB / on-prem / Oracle 19c, 21c, 23ai, 26ai non-Autonomous) from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Oracle Database, generic Oracle DB, on-prem Oracle, plain Oracle JDBC, port 1521, non-Autonomous Oracle. Read-write. Auth is host/port + database name + user/password.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# `aidp-oracle-db` — Generic Oracle Database via AIDP `aidataplatform`
+
+For non-Autonomous Oracle DBs — Oracle on Compute, Base DB, on-prem, customer-managed Oracle 19c/21c/23ai/26ai. Auth is plain user/password over TCP 1521.
+
+## When to use
+- User wants to read or write a non-Autonomous Oracle Database from an AIDP notebook.
+- User mentions: "Oracle Database", "generic Oracle DB", "on-prem Oracle", "Oracle 19c", "Oracle 21c", "Oracle 23ai non-Autonomous", "Base DB", "Oracle on Compute".
+- User has a host/port + plain user/password (no wallet, no IAM DB-Token).
+
+## When NOT to use
+- For Autonomous DB family (ALH/ADW/ATP) → [`aidp-alh`](../aidp-alh/SKILL.md). Autonomous always uses TCPS + wallet (or IAM DB-Token) — `aidp-oracle-db` won't work.
+- For Exadata Cloud Service → [`aidp-exacs`](../aidp-exacs/SKILL.md). ExaCS has its own NNE pattern.
+- For PeopleSoft / Siebel — those run on Oracle DB but have their own dedicated skills with the right schema defaults.
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Network: cluster must reach the Oracle DB host on the listener port (typically 1521). For private DBs in customer VCNs, VCN peering is required.
+3. Env vars / OCI Vault secrets:
+   - `ORADB_HOST`, `ORADB_PORT` (typically `1521`)
+   - `ORADB_DATABASE_NAME` (Oracle SID or service name)
+   - `ORADB_USER`, `ORADB_PASSWORD`
+   - `ORADB_SCHEMA`, `ORADB_TABLE`
+
+## Read (inline options)
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    host=os.environ["ORADB_HOST"],
+    port=int(os.environ.get("ORADB_PORT", "1521")),
+    database_name=os.environ["ORADB_DATABASE_NAME"],
+    user=os.environ["ORADB_USER"],
+    password=os.environ["ORADB_PASSWORD"],
+    schema=os.environ["ORADB_SCHEMA"],
+    table=os.environ["ORADB_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Write (inline options)
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    host=os.environ["ORADB_HOST"],
+    port=int(os.environ.get("ORADB_PORT", "1521")),
+    database_name=os.environ["ORADB_DATABASE_NAME"],
+    user=os.environ["ORADB_USER"],
+    password=os.environ["ORADB_PASSWORD"],
+    schema=os.environ["ORADB_SCHEMA"],
+    table=os.environ["ORADB_TARGET_TABLE"],
+    extra={"write.mode": "APPEND"},   # CREATE | APPEND | OVERWRITE
+)
+df.write.format(AIDP_FORMAT).options(**opts).save()
+```
+
+## Read via existing external catalog (`catalog.id`)
+
+If your AIDP workspace already has the Oracle DB registered as an external catalog, drop the host/port/credentials entirely and reference the catalog by id:
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    schema=os.environ["ORADB_SCHEMA"],
+    table=os.environ["ORADB_TABLE"],
+    extra={"catalog.id": os.environ["ORADB_CATALOG_ID"]},
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+Or use three-part naming via `spark.table()`:
+
+```python
+df = spark.table(f"{os.environ['ORADB_CATALOG_ID']}.{os.environ['ORADB_SCHEMA']}.{os.environ['ORADB_TABLE']}")
+df.show(10)
+df.write.mode("overwrite").saveAsTable(
+    f"{os.environ['ORADB_CATALOG_ID']}.{os.environ['ORADB_SCHEMA']}.{os.environ['ORADB_TARGET_TABLE']}"
+)
+```
+
+## Pushdown SQL
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    host=os.environ["ORADB_HOST"],
+    port=int(os.environ.get("ORADB_PORT", "1521")),
+    database_name=os.environ["ORADB_DATABASE_NAME"],
+    user=os.environ["ORADB_USER"],
+    password=os.environ["ORADB_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT department_id, COUNT(*) AS headcount, SUM(salary) AS total "
+            "FROM HR.EMPLOYEES "
+            "WHERE hire_date >= DATE '2024-01-01' "
+            "GROUP BY department_id"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show()
+```
+
+## Gotchas
+- **`database.name` is the Oracle SID or service name**, not the schema. Easy mix-up.
+- **Plain user/password only.** Wallets and IAM DB-Tokens are Autonomous-DB-only — for those, use `aidp-alh`.
+- **Network reachability** is the most common failure. From the cluster: `socket.create_connection((host, 1521), timeout=8)`. Failure = network problem (NSG / route table / DNS), not auth.
+- **Write modes** — `CREATE` (fail if exists), `APPEND`, `OVERWRITE`. Use `MERGE` only via `pushdown.sql` (`MERGE INTO ... WHEN MATCHED ...`) or three-part `saveAsTable` with `write.merge.keys`.
+- **NLS settings.** Default Oracle dates can come back with timezone surprises. Set `extra={"oracle.jdbc.timezoneAsRegion": "false"}` if you see TZ drift.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples → `data-engineering/ingestion/Read_Write_Oracle_Ecosystem_Connectors/Oracle_Database.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_Oracle_Ecosystem_Connectors/Oracle_Database.ipynb)

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-peoplesoft/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-peoplesoft/SKILL.md
@@ -1,0 +1,81 @@
+---
+description: Read from Oracle PeopleSoft into a Spark DataFrame in an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions PeopleSoft, PSFT, HCM, FSCM, Campus Solutions, or has a PeopleSoft host/port. Auth is host/port + database name + user/password. Read-only.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# `aidp-peoplesoft` — Oracle PeopleSoft via AIDP `aidataplatform`
+
+## When to use
+- User wants to ingest PeopleSoft data (HCM, FSCM, Campus Solutions, ELM, CRM) into a Spark DataFrame from an AIDP notebook.
+- User mentions: "PeopleSoft", "PSFT", "PS HCM", "Campus Solutions".
+
+## When NOT to use
+- For Oracle Autonomous DB family (ALH/ADW/ATP) → [`aidp-alh`](../aidp-alh/SKILL.md).
+- For generic Oracle DB on Compute / Base DB / on-prem → [`aidp-oracle-db`](../aidp-oracle-db/SKILL.md).
+- For Oracle Siebel → [`aidp-siebel`](../aidp-siebel/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Env vars / OCI Vault secrets:
+   - `PSFT_HOST` (PeopleSoft DB host)
+   - `PSFT_PORT` (typically `1521` for the underlying Oracle DB)
+   - `PSFT_DATABASE_NAME` (Oracle SID / service)
+   - `PSFT_USER`, `PSFT_PASSWORD`
+   - `PSFT_SCHEMA` (typically `SYSADM`)
+   - `PSFT_TABLE` (PeopleSoft record table, e.g. `PS_JOB`, `PS_VOUCHER`)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="ORACLE_PEOPLESOFT",
+    host=os.environ["PSFT_HOST"],
+    port=int(os.environ["PSFT_PORT"]),
+    database_name=os.environ["PSFT_DATABASE_NAME"],
+    user=os.environ["PSFT_USER"],
+    password=os.environ["PSFT_PASSWORD"],
+    schema=os.environ.get("PSFT_SCHEMA", "SYSADM"),
+    table=os.environ["PSFT_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Pushdown SQL
+
+Push a complete source query at the database — connector skips schema/table option building and runs the SQL verbatim. Useful for joins, filters, derived columns where you don't want Spark to fetch the full table.
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_PEOPLESOFT",
+    host=os.environ["PSFT_HOST"],
+    port=int(os.environ["PSFT_PORT"]),
+    database_name=os.environ["PSFT_DATABASE_NAME"],
+    user=os.environ["PSFT_USER"],
+    password=os.environ["PSFT_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT EMPLID, EFFDT, DEPTID, JOBCODE "
+            "FROM SYSADM.PS_JOB "
+            "WHERE EFF_STATUS = 'A' AND EFFDT >= DATE '2025-01-01'"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Gotchas
+- **Connector is read-only.** PeopleSoft is treated as a source-of-truth system; writes back must go through PeopleSoft's own application APIs, not Spark.
+- **Underlying Oracle DB.** Most PeopleSoft installs run on Oracle DB; the connector hits the DB directly. Network reachability rules from `aidp-oracle-db` apply — cluster pod CIDR needs L3 path to the PeopleSoft DB host.
+- **`SYSADM` schema** is the standard PeopleSoft owner. Ensure the connector user has `SELECT` privs on the PS_* tables you need — PeopleSoft tables are not granted to PUBLIC by default.
+- **Read row count** before pulling — PeopleSoft fact tables can have hundreds of millions of rows. Always include a `WHERE` filter via `pushdown.sql` for production.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples → `data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_PeopleSoft.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_PeopleSoft.ipynb)

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-rest-generic/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-rest-generic/SKILL.md
@@ -68,6 +68,33 @@ extra={
 }
 ```
 
+## Manifest from a workspace / volume path (`manifest.path`)
+
+If the manifest is a static file you've uploaded to your AIDP workspace or a Volume — instead of being served over HTTP — use `manifest.path` instead of `manifest.url`. Same shape, different source. Useful when the manifest is hand-authored or version-pinned alongside your notebook.
+
+```python
+opts = aidataplatform_options(
+    type="GENERIC_REST",
+    user=os.environ["REST_USER"],
+    password=os.environ["REST_PASSWORD"],
+    schema="default",
+    extra={
+        "base.url":      os.environ["REST_BASE_URL"],
+        "manifest.path": "/Volumes/myvol/manifests/orders_api.json",
+        "auth.type":     "basic",
+        "api":           "searchOrders",
+        "derived.property.status": "OPEN",
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+```
+
+The path can be:
+- `/Volumes/<catalog>/<schema>/<volume>/path/to/manifest.json` (AIDP Volume)
+- `/Workspace/Shared/.../manifest.json` (workspace file — works but FUSE-flaky)
+
+Volume paths are the preferred location.
+
 ## Gotchas
 - **`auth.type=basic` only.** If the API uses OAuth / API key headers / mTLS, this connector won't help — use the Python `requests` path.
 - **Manifest must be reachable from the AIDP cluster's VCN.** Egress restrictions apply.

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-salesforce/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-salesforce/SKILL.md
@@ -1,0 +1,83 @@
+---
+description: Read from Salesforce into a Spark DataFrame in an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Salesforce, SFDC, Sales Cloud, Service Cloud, Account, Opportunity, Lead, sObject, SOQL. Auth is host/port + user/password. Read-only.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# `aidp-salesforce` — Salesforce via AIDP `aidataplatform`
+
+## When to use
+- User wants to ingest Salesforce data (Account, Opportunity, Lead, Contact, custom sObjects) into a Spark DataFrame from an AIDP notebook.
+- User mentions: "Salesforce", "SFDC", "Sales Cloud", "Service Cloud", "sObject", "SOQL", a Salesforce object name (Account, Opportunity, etc.).
+
+## When NOT to use
+- For arbitrary REST APIs with a custom manifest → [`aidp-rest-generic`](../aidp-rest-generic/SKILL.md).
+- For Oracle CX/CRM → [`aidp-siebel`](../aidp-siebel/SKILL.md) (Siebel) or Fusion CX via [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Env vars / OCI Vault secrets:
+   - `SFDC_HOST` (Salesforce login host, e.g. `login.salesforce.com` or `<my-domain>.my.salesforce.com`)
+   - `SFDC_PORT` (typically `443`)
+   - `SFDC_DATABASE_NAME` (org name / database identifier; for most tenants this is just the org name)
+   - `SFDC_USER` (Salesforce username — typically `<email>`)
+   - `SFDC_PASSWORD` (password concatenated with security token: `<password><security-token>`)
+   - `SFDC_SCHEMA` (typically `SFORCE` for the connector)
+   - `SFDC_TABLE` (sObject API name, e.g. `Account`, `Opportunity`, `Custom_Object__c`)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="SFORCE",
+    host=os.environ["SFDC_HOST"],
+    port=int(os.environ.get("SFDC_PORT", "443")),
+    database_name=os.environ["SFDC_DATABASE_NAME"],
+    user=os.environ["SFDC_USER"],
+    password=os.environ["SFDC_PASSWORD"],
+    schema=os.environ.get("SFDC_SCHEMA", "SFORCE"),
+    table=os.environ["SFDC_TABLE"],   # e.g. "Account", "Opportunity"
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Pushdown SQL
+
+Use `pushdown.sql` to push a SOQL-like query at the source — useful for filtering on indexed fields, joins via relationship paths, or LIMIT semantics.
+
+```python
+opts = aidataplatform_options(
+    type="SFORCE",
+    host=os.environ["SFDC_HOST"],
+    port=int(os.environ.get("SFDC_PORT", "443")),
+    database_name=os.environ["SFDC_DATABASE_NAME"],
+    user=os.environ["SFDC_USER"],
+    password=os.environ["SFDC_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT Id, Name, AnnualRevenue, BillingCountry "
+            "FROM Account "
+            "WHERE AnnualRevenue > 1000000 AND BillingCountry = 'United States'"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Gotchas
+- **`type` is `SFORCE`, not `SALESFORCE`.** Easy to get wrong if you're following the human-readable name. The connector type literally says `SFORCE`.
+- **Password requires the security token appended.** Salesforce username/password auth needs `<password><security-token>` concatenated as a single string. The security token is reset each time the user changes their password — emailed to the user.
+- **API limits.** Salesforce enforces per-org daily API call quotas. Bulk reads count against the quota. Use `pushdown.sql` with selective filters and field projection to minimize calls.
+- **Connector is read-only.** Salesforce writes (create/update sObjects) need to go through the Salesforce REST/Bulk API or the Composite API directly.
+- **Custom objects** end in `__c` (e.g. `Project__c`). Custom fields end in `__c` too — always include the trailing `__c` in `pushdown.sql`.
+- **Field-level security.** The connector user inherits Salesforce profile + permission sets. Fields hidden by FLS won't appear in the result.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples → `data-engineering/ingestion/Read_Only_Ingestion_Connectors/Salesforce.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors/Salesforce.ipynb)

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-siebel/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-siebel/SKILL.md
@@ -1,0 +1,82 @@
+---
+description: Read from Oracle Siebel CRM into a Spark DataFrame in an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Siebel, Siebel CRM, S_CONTACT, S_ORG_EXT, or has a Siebel host/port. Auth is host/port + database name + user/password. Read-only.
+allowed-tools: Read, Write, Edit, Bash
+---
+
+# `aidp-siebel` — Oracle Siebel CRM via AIDP `aidataplatform`
+
+## When to use
+- User wants to ingest Siebel CRM data (contacts, accounts, opportunities, service requests) into a Spark DataFrame from an AIDP notebook.
+- User mentions: "Siebel", "Siebel CRM", "S_CONTACT", "S_ORG_EXT", "S_OPTY", Siebel base tables.
+
+## When NOT to use
+- For Oracle Autonomous DB family (ALH/ADW/ATP) → [`aidp-alh`](../aidp-alh/SKILL.md).
+- For Oracle PeopleSoft → [`aidp-peoplesoft`](../aidp-peoplesoft/SKILL.md).
+- For generic Oracle DB → [`aidp-oracle-db`](../aidp-oracle-db/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Env vars / OCI Vault secrets:
+   - `SIEBEL_HOST`, `SIEBEL_PORT` (typically `1521`)
+   - `SIEBEL_DATABASE_NAME` (Oracle SID / service)
+   - `SIEBEL_USER`, `SIEBEL_PASSWORD`
+   - `SIEBEL_SCHEMA` (typically `SIEBEL`)
+   - `SIEBEL_TABLE` (a Siebel base table, e.g. `S_CONTACT`, `S_ORG_EXT`)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="ORACLE_SIEBEL",
+    host=os.environ["SIEBEL_HOST"],
+    port=int(os.environ["SIEBEL_PORT"]),
+    database_name=os.environ["SIEBEL_DATABASE_NAME"],
+    user=os.environ["SIEBEL_USER"],
+    password=os.environ["SIEBEL_PASSWORD"],
+    schema=os.environ.get("SIEBEL_SCHEMA", "SIEBEL"),
+    table=os.environ["SIEBEL_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Pushdown SQL
+
+Use `pushdown.sql` to run a complete source query — push joins, filters, and aggregations to the Siebel DB instead of pulling whole base tables into Spark.
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_SIEBEL",
+    host=os.environ["SIEBEL_HOST"],
+    port=int(os.environ["SIEBEL_PORT"]),
+    database_name=os.environ["SIEBEL_DATABASE_NAME"],
+    user=os.environ["SIEBEL_USER"],
+    password=os.environ["SIEBEL_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT C.ROW_ID, C.LAST_NAME, C.FST_NAME, O.NAME AS ACCOUNT "
+            "FROM SIEBEL.S_CONTACT C "
+            "JOIN SIEBEL.S_ORG_EXT O ON C.PR_HELD_POSTN_ID = O.ROW_ID "
+            "WHERE C.STATUS_CD = 'Active'"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(**opts).load()
+df.show(10)
+```
+
+## Gotchas
+- **Connector is read-only.** Siebel data should be written back through Siebel's EAI/REST channels, not Spark. The connector is intentionally one-way.
+- **Underlying Oracle DB.** Siebel runs on Oracle DB; network reachability rules from `aidp-oracle-db` apply.
+- **`SIEBEL` schema owner.** Standard Siebel install owns all base tables (`S_*`) under the `SIEBEL` schema. The connector user needs `SELECT` privs.
+- **Soft-delete columns.** Siebel uses `ROW_ID` keys and `LAST_UPD` for incremental ingest. Filter with `WHERE LAST_UPD > :since` via `pushdown.sql` for delta loads.
+- **Audit columns.** `CREATED`, `CREATED_BY`, `LAST_UPD`, `LAST_UPD_BY` are populated by triggers on every row — useful for change tracking.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples → `data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_Siebel.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_Siebel.ipynb)

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-snowflake/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/skills/aidp-snowflake/SKILL.md
@@ -18,9 +18,9 @@ Bridge AIDP Spark to Snowflake using the official Snowflake Spark connector. Use
 
 The Snowflake Spark connector is **not** in the AIDP cluster image by default. Two ways to get it in.
 
-### Option A — Runtime-load (recommended; no cluster restart) ★ live-validated
+### Option A — Runtime-load (recommended; no cluster restart)
 
-The plugin's `add_spark_connector_at_runtime` helper downloads + registers both JARs in the running Spark session. Live-validated on the AIDP `tpcds` cluster (Spark 3.5.0) — see `tests/live-results/row20.json`.
+The plugin's `add_spark_connector_at_runtime` helper downloads + registers both JARs in the running Spark session.
 
 ```python
 from oracle_ai_data_platform_connectors.jdbc import (

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/tests/live-results/RESULTS.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/tests/live-results/RESULTS.md
@@ -1,7 +1,7 @@
 # Live-test results
 
 
-**Summary:** 17 PASS, 0 DEFERRED, 4 NOT RUN out of 21 rows. Rows 16, 17, 21, 23 are explicitly ship-as-is (connector code + example notebook ship; customer validates against their own endpoint).
+**Summary:** Rows 16, 17, 21, 23 ship as-is (connector code + example notebook ship; customer validates against their own endpoint). All other rows have a corresponding `row<N>.json` artifact alongside this file.
 
 Row IDs 4 (ExaCS Wallet TCPS), 5 (ExaCS IAM DB-Token), 7 + 8 (`aidp-bds-hive` Kerberos + LDAP), and 18 (`aidp-oracle-db` plain TCP 1521) were removed. ExaCS rows 4/5 aren't supported by AIDP notebooks for ExaCS clusters. The `aidp-bds-hive` skill was dropped from the plugin (BDS Hive not in scope for this connector pack). Row 18 was dropped because the `aidp-alh` family already covers Oracle 26ai connectivity end-to-end across all three auth methods (wallet, IAM DB-Token, aidataplatform format handler) — a separate plain-1521 Oracle DB skill adds no incremental coverage and the JDBC code path is identical.
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/tests/test_aidataplatform.py
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/tests/test_aidataplatform.py
@@ -147,3 +147,121 @@ class TestAidataplatformOptionsGenericRest:
         assert out["derived.property.orderNo"] == "12345"
         # No host/port/table for the rest shape
         assert "host" not in out
+
+
+class TestAidataplatformOptionsV050NewTypes:
+    """Tests for the 5 new connector types added in v0.5.0 (oracle-samples PR #46)."""
+
+    def test_peoplesoft_shape(self):
+        out = aidataplatform_options(
+            type="ORACLE_PEOPLESOFT",
+            host="psft-db.example.com",
+            port=1521,
+            database_name="HCMDB",
+            user="PS_USER",
+            password="pw",
+            schema="SYSADM",
+            table="PS_JOB",
+        )
+        assert out["type"] == "ORACLE_PEOPLESOFT"
+        assert out["host"] == "psft-db.example.com"
+        assert out["port"] == "1521"
+        assert out["database.name"] == "HCMDB"
+        assert out["schema"] == "SYSADM"
+        assert out["table"] == "PS_JOB"
+
+    def test_siebel_shape(self):
+        out = aidataplatform_options(
+            type="ORACLE_SIEBEL",
+            host="siebel-db.example.com",
+            port=1521,
+            database_name="SIEBELDB",
+            user="SIEBEL_USER",
+            password="pw",
+            schema="SIEBEL",
+            table="S_CONTACT",
+        )
+        assert out["type"] == "ORACLE_SIEBEL"
+        assert out["schema"] == "SIEBEL"
+        assert out["table"] == "S_CONTACT"
+
+    def test_salesforce_uses_sforce_type(self):
+        """Salesforce connector type literal is ``SFORCE``, not ``SALESFORCE``."""
+        out = aidataplatform_options(
+            type="SFORCE",
+            host="login.salesforce.com",
+            port=443,
+            database_name="myorg",
+            user="user@example.com",
+            password="pwd+token",
+            schema="SFORCE",
+            table="Account",
+        )
+        assert out["type"] == "SFORCE"
+        assert out["table"] == "Account"
+
+    def test_hive_no_database_name(self):
+        """Hive connector uses ``schema`` directly (Hive database name)."""
+        out = aidataplatform_options(
+            type="HIVE",
+            host="hs2.example.com",
+            port=10000,
+            user="hive",
+            password="hivepw",
+            schema="sales_db",
+            table="transactions",
+        )
+        assert out["type"] == "HIVE"
+        assert out["schema"] == "sales_db"
+        assert "database.name" not in out  # Hive doesn't use database.name
+
+    def test_oracle_db_with_catalog_id(self):
+        """v0.5.0 pattern: use catalog.id and skip host/port/user/password."""
+        out = aidataplatform_options(
+            type="ORACLE_DB",
+            schema="HR",
+            table="EMPLOYEES",
+            extra={"catalog.id": "my-oracle-catalog"},
+        )
+        assert out == {
+            "type": "ORACLE_DB",
+            "schema": "HR",
+            "table": "EMPLOYEES",
+            "catalog.id": "my-oracle-catalog",
+        }
+
+    def test_pushdown_sql_extra(self):
+        """v0.5.0 pattern: pushdown.sql replaces schema/table option building."""
+        out = aidataplatform_options(
+            type="ORACLE_PEOPLESOFT",
+            host="h",
+            port=1521,
+            database_name="HCMDB",
+            user="u",
+            password="p",
+            extra={"pushdown.sql": "SELECT 1 FROM DUAL"},
+        )
+        assert out["pushdown.sql"] == "SELECT 1 FROM DUAL"
+        # When pushdown.sql is used, schema/table aren't in the dict
+        assert "schema" not in out
+        assert "table" not in out
+
+    def test_write_mode_merge_with_keys(self):
+        """v0.5.0 pattern: write.mode=MERGE requires write.merge.keys."""
+        out = aidataplatform_options(
+            type="ORACLE_DB",
+            host="h", port=1521, database_name="DB",
+            user="u", password="p", schema="HR", table="EMPLOYEES",
+            extra={"write.mode": "MERGE", "write.merge.keys": "EMPLOYEE_ID"},
+        )
+        assert out["write.mode"] == "MERGE"
+        assert out["write.merge.keys"] == "EMPLOYEE_ID"
+
+    def test_manifest_path_for_rest(self):
+        """v0.5.0 pattern: REST connector accepts manifest.path (workspace/volume)."""
+        out = aidataplatform_options(
+            type="GENERIC_REST",
+            extra={"manifest.path": "/Volumes/myvol/manifests/my_api.json"},
+        )
+        assert out["type"] == "GENERIC_REST"
+        assert out["manifest.path"] == "/Volumes/myvol/manifests/my_api.json"


### PR DESCRIPTION
## Summary

Updates the Oracle AI Data Platform Workbench Spark Connectors Claude Code plugin from v0.4.1 → **v0.5.0** to adopt the new sample patterns from [PR #46 — Update connector sample notebooks](https://github.com/oracle-samples/oracle-aidp-samples/pull/46).

## What's added

### 5 new connector skills (18 → 23 connectors)

| Skill | Target | aidataplatform `type` |
|---|---|---|
| **`aidp-oracle-db`** | Generic Oracle DB (Compute / Base DB / on-prem / 19c-26ai non-Autonomous) — read-write | `ORACLE_DB` |
| **`aidp-peoplesoft`** | Oracle PeopleSoft (HCM, FSCM, Campus Solutions) — read-only | `ORACLE_PEOPLESOFT` |
| **`aidp-siebel`** | Oracle Siebel CRM — read-only | `ORACLE_SIEBEL` |
| **`aidp-salesforce`** | Salesforce — read-only | `SFORCE` (note: literal type is `SFORCE`) |
| **`aidp-hive`** | Apache Hive HiveServer2 (non-Kerberos) — read-write | `HIVE` |

### Cross-cutting patterns (from PR #46)

- **`pushdown.sql`** — push complete source SQL queries at the database
- **`catalog.id`** — reference pre-registered AIDP external catalogs by id
- **`manifest.path`** — REST manifest as workspace/Volume path (alternative to `manifest.url`)
- **`write.mode=MERGE`** + `write.merge.keys`

### Example notebooks

Cherry-picked verbatim from the per-connector notebooks added in PR #46:
- `examples/peoplesoft_read.ipynb`
- `examples/siebel_read.ipynb`
- `examples/salesforce_read.ipynb`
- `examples/hive_read_write.ipynb`
- `examples/oracle_db_read_write.ipynb`

### Updated existing files

- `aidp-connectors-overview/SKILL.md` — routing skill expanded with new keyword sections (Oracle/OCI, RDBMS/Hadoop, SaaS, multi-cloud)
- `aidp-rest-generic/SKILL.md` — added `manifest.path` (workspace/Volume) section alongside the existing `manifest.url` pattern
- `scripts/oracle_ai_data_platform_connectors/aidataplatform.py` — docstring updated; helper still accepts any `type` string (no behavior change)
- `tests/test_aidataplatform.py` — 8 new unit tests covering each new connector type + catalog.id + pushdown.sql + write.mode=MERGE + manifest.path

## Validation

- `claude plugin validate ai/claude-code-plugins/oracle-ai-data-platform-workbench-spark-connectors/` ✓
- `python -m pytest ai/claude-code-plugins/.../tests/` ✓ (53/53 passing — was 45)
- 25 skills total (23 connectors + bootstrap + routing)

## Companion change

After merge, the corresponding entries in `anthropics/claude-plugins-community` and `anthropics/claude-plugins-official` will need their pinned SHAs bumped to this PR's merge commit. I'll file the SHA-bump PRs once this lands.

## Test plan

- [x] `claude plugin validate .` passes against the new subdirectory
- [x] `python -m pytest tests/` passes (53/53)
- [ ] Reviewer confirms the 5 new SKILL.md files match the new per-connector notebooks shipped in PR #46
- [ ] After merge: file SHA-bump PRs to claude-plugins-community + claude-plugins-official