### PR TITLE
Sample/aidp chat client web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,9 +92,10 @@ temp/
 .cache/
 
 # =========================
-# Local agent config (may contain secrets)
+# Local agent / deploy config (may contain secrets)
 # =========================
 ai/agent-flows/code-first/multi-mcp-chat-agent/config.yaml
 ai/agent-flows/code-first/multi-mcp-chat-agent/oac-jwt-key.pem
 ai/agent-flows/code-first/multi-mcp-chat-agent/oac-jwt-key.txt
 ai/agent-flows/code-first/multi-mcp-chat-agent/oac-cert.pem
+ai/aidp_chat_client/web_ui/config-deploy.yaml

--- a/README.md
+++ b/README.md
@@ -177,6 +177,12 @@ Notebooks covering generative AI, NLP, ML model training, and LLM-powered analyt
 |---|---|
 | [Agent Flow Schedule Trigger](ai/agent-flows/misc/agent-flow-schedule-trigger/task_notebook.ipynb) | Invoke AIDP agent flows via REST API using OCI request signing, demonstrating programmatic agent orchestration with custom message handling. |
 
+#### Agent Chat Clients
+
+| Sample | Description |
+|---|---|
+| [AIDP Agent Chat — Web UI](ai/aidp_chat_client/web_ui/README.md) | Browser chat UI for any deployed AIDP agent: a Flask proxy that handles OCI request signing plus a single-page HTML frontend. Includes a one-command deploy script for OCI Container Instances. |
+
 #### Code-First Agent Flows
 
 | Sample | Description |

--- a/ai/aidp_chat_client/README.md
+++ b/ai/aidp_chat_client/README.md
@@ -11,6 +11,8 @@ python standalone_endpoint_test.py
 ```
 No installation required! Just edit your endpoint URL and config path in the file.
 
+**Prefer a browser UI?** See [web_ui/](web_ui/) for a minimal Flask proxy + single-page chat that streams responses from a deployed agent endpoint.
+
 See [QUICKSTART.md](QUICKSTART.md) for detailed quick start guide.
 
 ## Features

--- a/ai/aidp_chat_client/setup.py
+++ b/ai/aidp_chat_client/setup.py
@@ -18,7 +18,8 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/oracle-samples/oracle-aidp-samples",
-    packages=find_packages(),
+    packages=["aidp_chat_client"],
+    package_dir={"aidp_chat_client": "."},
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/ai/aidp_chat_client/web_ui/Dockerfile
+++ b/ai/aidp_chat_client/web_ui/Dockerfile
@@ -1,0 +1,21 @@
+# Build context is the parent aidp_chat_client/ directory (set by deploy.py),
+# so this Dockerfile sees both the library source and the web_ui/ folder.
+FROM python:3.11-slim
+
+# Don't buffer stdout/stderr — without this, Flask request-handler prints can
+# sit in a buffer for ages before showing up in container logs, making
+# diagnostics painful.
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY . /app/
+
+RUN pip install --no-cache-dir . && \
+    pip install --no-cache-dir -r web_ui/requirements.txt
+
+WORKDIR /app/web_ui
+
+EXPOSE 5001
+
+CMD ["python", "server.py"]

--- a/ai/aidp_chat_client/web_ui/README.md
+++ b/ai/aidp_chat_client/web_ui/README.md
@@ -84,9 +84,10 @@ Each constant also reads from an environment variable (`AIDP_AGENT_URL`,
 
 `deploy.py` builds the Docker image, pushes it to OCIR, sets up a VCN/subnet
 with port 5001 open, and creates a Container Instance running the proxy. It
-auto-discovers tenancy, region, namespace, and compartment from
-`~/.oci/config`, prompts to create an OCIR auth token if you don't have one
-free, and prints the public URL when done.
+auto-discovers tenancy, region, and namespace from `~/.oci/config`, prompts
+you to pick a compartment (or reads `DEPLOY_COMPARTMENT_ID` /
+`config-deploy.yaml`), prompts to create an OCIR auth token if you don't
+have one free, and prints the public URL when done.
 
 ```bash
 python3 -m pip install oci pyyaml   # if not already installed

--- a/ai/aidp_chat_client/web_ui/README.md
+++ b/ai/aidp_chat_client/web_ui/README.md
@@ -1,0 +1,202 @@
+# AIDP Agent Chat — Web UI
+
+A minimal browser chat UI for a deployed AIDP agent endpoint. Demonstrates how
+to put a frontend in front of an agent without exposing OCI credentials to the
+browser.
+
+## How it works
+
+```
+   browser  ──HTTP──▶  Flask proxy  ──signed HTTPS──▶  AIDP agent endpoint
+   (index.html)        (server.py)                     (gateway.aidp...)
+              ◀──SSE──            ◀────── SSE ───────
+```
+
+The browser cannot sign OCI requests safely, so a local Flask proxy holds your
+OCI credentials, signs each call, and streams the agent's SSE response back to
+the page unchanged. The proxy reuses `AIDPChatClient` from the parent library
+to construct the signer (API key or security token).
+
+## Prerequisites
+
+- Python 3.8+
+- An OCI config file (typically `~/.oci/config`)
+- A deployed AIDP agent and its full chat endpoint URL — copy it straight from
+  the AIDP console after deployment (looks like
+  `https://gateway.aidp.<region>.oci.oraclecloud.com/agentendpoint/<id>/chat`).
+  If you don't have an agent yet, [`multi-mcp-chat-agent`](../../agent-flows/code-first/multi-mcp-chat-agent/)
+  in this repo is one ready-to-deploy option you can chat with.
+
+## Run it
+
+From this directory:
+
+```bash
+python3 -m pip install -e ..                # install the parent aidp_chat_client library
+python3 -m pip install -r requirements.txt  # flask + flask-cors
+```
+
+> Use `python3 -m pip` (not bare `pip`) so the deps land in the same Python
+> that runs the script — on macOS the two often resolve to different installs
+> and you'll get `ModuleNotFoundError: aidp_chat_client` otherwise.
+
+Open [server.py](server.py) and set `AGENT_URL` to the full chat endpoint URL
+from the AIDP console (the constants block is at the top of the file). Then:
+
+```bash
+python3 server.py
+```
+
+Open [http://localhost:5001](http://localhost:5001).
+
+## Configuration
+
+All configuration lives at the top of [server.py](server.py):
+
+| Constant | Default | Purpose |
+|---|---|---|
+| `AGENT_URL` | placeholder | Full chat endpoint URL from the AIDP console |
+| `OCI_CONFIG_PATH` | `None` (uses `~/.oci/config`) | Path to your OCI config file |
+| `OCI_PROFILE` | `"DEFAULT"` | Profile inside the config file |
+| `AUTH` | `"api_key"` | `"api_key"`, `"security_token"`, or `"resource_principal"` |
+
+Each constant also reads from an environment variable (`AIDP_AGENT_URL`,
+`AIDP_AUTH`) so you can override without editing the file — which is how
+`deploy.py` injects values when deploying to a Container Instance.
+
+## Files
+
+- `server.py` — Flask proxy. Loads OCI auth via the parent library, exposes
+  `POST /chat`, streams SSE through to the browser.
+- `index.html` — single-page chat UI. Generates a per-tab `session_id`, parses
+  `data: {...}` SSE events, and renders agent output as markdown
+  (`marked` + `DOMPurify` from CDN).
+- `requirements.txt` — proxy-only deps (`oci` and `requests` come transitively
+  from the parent library).
+- `Dockerfile` — Python image used by `deploy.py`. Build context is the parent
+  `aidp_chat_client/` directory so the library is installable inside the image.
+- `deploy.py` — one-command build + push + deploy to an OCI Container Instance.
+- `config-deploy.sample.yaml` — template for `deploy.py`. Copy to
+  `config-deploy.yaml` and fill in your values (compartment, agent URL, etc.)
+  to skip interactive prompts. The real `config-deploy.yaml` is gitignored.
+
+## Deploy to OCI Container Instances
+
+`deploy.py` builds the Docker image, pushes it to OCIR, sets up a VCN/subnet
+with port 5001 open, and creates a Container Instance running the proxy. It
+auto-discovers tenancy, region, namespace, and compartment from
+`~/.oci/config`, prompts to create an OCIR auth token if you don't have one
+free, and prints the public URL when done.
+
+```bash
+python3 -m pip install oci pyyaml   # if not already installed
+python3 deploy.py                    # interactive
+# or:  python3 deploy.py --yes
+```
+
+#### Skip the prompts: `config-deploy.yaml`
+
+`deploy.py` will prompt for a handful of things every run (region,
+compartment, agent URL, OCIR auth token). To skip those, copy
+[`config-deploy.sample.yaml`](config-deploy.sample.yaml) to
+`config-deploy.yaml`, fill in the values, and re-run. The script reads it
+from the same directory and uses the values directly. Anything left blank
+falls back to the prompt. The OCIR auth token can also live in this file,
+but the file is gitignored — never commit it.
+
+#### Manual / bring-your-own deploy
+
+`deploy.py` is opinionated (creates a VCN, OCIR repo, Container Instance,
+IAM Dynamic Group + Policy). If you'd rather use your own infrastructure
+or CI/CD pipeline, the moving parts are:
+
+1. **Build** the Docker image. Build context must be the parent
+   `aidp_chat_client/` directory so the library is installable inside
+   the image:
+   ```bash
+   cd aidp_chat_client
+   docker build -f web_ui/Dockerfile -t my-aidp-chat-ui:latest .
+   ```
+2. **Push** to your container registry of choice.
+3. **Run** with these environment variables set:
+   - `AIDP_AGENT_URL` — full chat endpoint URL
+   - `AIDP_AUTH` — `resource_principal` (recommended for non-laptop
+     deployments) or `api_key` if you mount an OCI config file
+4. **Identity setup** — same two layers documented below
+   (IAM Dynamic Group + Policy, plus AIDP Workbench membership).
+
+### Required: identity setup for the deployed container
+
+Inside the container, the proxy authenticates as the Container Instance itself
+(an OCI resource principal). For that principal to actually invoke the AIDP
+agent, **two layers of access** must be in place:
+
+#### Layer 1 — IAM (Dynamic Group + Policy)
+
+Grants the resource principal permission on the underlying OCI resources.
+
+`deploy.py` checks for both at startup and refuses to deploy if they're
+missing — so you'll get an immediate, clear error instead of a deploy that
+"succeeds" and then fails on the first chat. The check is read-only (only
+needs `inspect` on identity), so any user who can deploy can also run it.
+
+You have two paths:
+
+- **Manual (default)** — create them once in the OCI Console:
+   1. **Dynamic Group** (in the Default identity domain) with this matching
+      rule:
+      ```
+      ALL {resource.type = 'computecontainerinstance', resource.compartment.id = '<COMPARTMENT_OCID>'}
+      ```
+   2. **Policy** in your compartment:
+      ```
+      Allow dynamic-group <DG_NAME> to use ai-data-platforms in compartment <COMPARTMENT_NAME>
+      ```
+   The script prints the exact rule and statement to paste, scoped to your
+   chosen compartment.
+
+- **Auto-create** — `python3 deploy.py --create-iam`. The script tries to
+  create both. Needs **tenancy-admin permissions** (Dynamic Groups live at
+  the tenancy root). Falls back to printing the manual instructions if perms
+  are insufficient or your tenancy uses Identity Domains (where DGs are
+  managed inside the domain console rather than the classic identity API).
+
+#### Layer 2 — AIDP Workbench membership
+
+> **Important:** IAM alone is not enough. The AIDP gateway adds its own
+> Workbench-level auth check on top of OCI IAM. Your dynamic group must also
+> be added as a **member of the AIDP Workbench** that hosts the agent.
+>
+> Symptom when this layer is missing: the gateway returns **404 Not Found**
+> on chat (not 401/403). The same URL works locally because your *user* has
+> Workbench access automatically — the resource principal does not.
+
+Steps:
+
+1. Get the OCID of the Dynamic Group `aidp-agent-chat-ui-dg` from the OCI
+   Console (Identity → Domains → Default → Dynamic Groups).
+2. Open the **AIDP Workbench** that hosts your agent.
+3. Go to the **Roles** tab in the left menu.
+4. Add the dynamic-group OCID as an **Admin** (simplest — narrower roles
+   would also work if AIDP exposes them for your use case).
+5. Save.
+
+After both layers are in place the resource principal can authenticate as
+the workbench, the gateway lets it through, and the agent responds.
+
+## Security note
+
+The proxy authenticates to the AIDP gateway as a **single principal** —
+your user (when running locally with `api_key` / `security_token`) or
+the Container Instance itself (when deployed with `resource_principal`).
+Whichever it is, **anyone who can reach the proxy chats as that
+principal**. There's no per-user auth in front of it.
+
+This is acceptable for:
+- Local dev on your laptop (only you can reach `localhost:5001`)
+- A Container Instance behind a VPN, private subnet, or IP allowlist
+
+Before exposing this on the public internet for shared use, add user
+authentication in front of the proxy (e.g. a reverse proxy with OAuth2
+or basic auth) and consider per-user scoping if your downstream agent
+supports it.

--- a/ai/aidp_chat_client/web_ui/config-deploy.sample.yaml
+++ b/ai/aidp_chat_client/web_ui/config-deploy.sample.yaml
@@ -1,0 +1,69 @@
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  AIDP Agent Chat UI — Deployment Configuration                   ║
+# ║                                                                  ║
+# ║  Copy this file to `config-deploy.yaml` and fill in your values. ║
+# ║  `deploy.py` reads it from the same directory and skips prompts  ║
+# ║  for any field set here. Anything left blank still falls back to ║
+# ║  the original interactive prompt or env-var override.            ║
+# ╚══════════════════════════════════════════════════════════════════╝
+
+
+# ─── Agent ─────────────────────────────────────────────────────────
+# Full /chat URL of the deployed AIDP agent. Copy this from the AIDP
+# console after deploying your agent. Pattern:
+#   https://gateway.aidp.<region>.oci.oraclecloud.com/agentendpoint/<id>/chat
+agent:
+  url: https://gateway.aidp.us-ashburn-1.oci.oraclecloud.com/agentendpoint/<AGENT_ID>/chat
+
+
+# ─── Deploy target ─────────────────────────────────────────────────
+deploy:
+  # OCI region the container instance + VCN go into. If omitted, the
+  # script uses whatever region your ~/.oci/config has as default.
+  region: us-ashburn-1
+
+  # Compartment where the Container Instance, VCN, and OCIR repo live.
+  # Paste the compartment OCID. To use the tenancy root, paste the
+  # tenancy OCID. If omitted, the script shows a numbered picker.
+  compartment_id: ocid1.compartment.oc1..XXXXXX
+
+  # Cosmetic / sizing — change only if you have a reason to.
+  display_name: aidp-agent-chat-ui
+  shape: CI.Standard.E4.Flex
+  cpus: 1
+  memory_gb: 2
+
+
+# ─── Container image ───────────────────────────────────────────────
+# The script tags the image as <region-key>.ocir.io/<namespace>/<repo>:<tag>
+# — only repo/tag are configurable here. region key and namespace are
+# auto-derived from your tenancy.
+container:
+  repo: aidp-agent-chat-ui
+  tag: latest
+
+
+# ─── IAM (advanced — usually leave alone) ──────────────────────────
+# Resource family used in the auto-generated policy. The default
+# 'ai-data-platforms' is the correct family — the AIDP gateway enforces
+# Workbench-level auth, which is gated by this family. Override only if
+# Oracle changes the family name in the future.
+iam:
+  policy_resource: ai-data-platforms
+
+
+# ─── OCIR auth token (SENSITIVE) ───────────────────────────────────
+# ⚠ DO NOT COMMIT a populated config-deploy.yaml to git — this file
+#   is .gitignored for that reason. Keep your sample (this file) clean
+#   and put real values only in your local config-deploy.yaml.
+#
+# If left blank, the script lists your existing tokens and offers to
+# create a new one (max 2 per user — OCI limit). Generate manually at:
+#   OCI Console → Identity → Users → your user → Auth Tokens
+ocir:
+  auth_token:
+
+
+# ─── NOT in this file (intentionally) ──────────────────────────────
+# • Tenancy OCID, OCIR namespace, OCIR username — auto-discovered
+#   from ~/.oci/config every run; nothing to configure.

--- a/ai/aidp_chat_client/web_ui/deploy.py
+++ b/ai/aidp_chat_client/web_ui/deploy.py
@@ -14,7 +14,7 @@ Prerequisites:
     Example matching rule:
         ALL {resource.type = 'computecontainerinstance', resource.compartment.id = '<COMPARTMENT_OCID>'}
     Example policy:
-        Allow dynamic-group <DG_NAME> to use genai-agent-endpoint in compartment <COMPARTMENT_NAME>
+        Allow dynamic-group <DG_NAME> to use ai-data-platforms in compartment <COMPARTMENT_NAME>
   - The Dynamic Group also added as a MEMBER of the AIDP Workbench that hosts
     the agent (Workbench → Roles → Admin). IAM alone is not enough — the AIDP
     gateway enforces its own Workbench auth and returns HTTP 404 on chat if

--- a/ai/aidp_chat_client/web_ui/deploy.py
+++ b/ai/aidp_chat_client/web_ui/deploy.py
@@ -34,6 +34,7 @@ import os
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import oci
 from oci.regions import REGIONS_SHORT_NAMES
@@ -261,8 +262,24 @@ def discover_config():
                 )
                 auth_token = resp.data.token
                 token_was_just_created = True
-                print(f"  Auth token created. Save this — it won't be shown again!")
-                print(f"  Token: {auth_token}")
+                # Write the freshly-created token to a 0600 file rather than
+                # stdout: the script is often invoked from CI/shared terminals
+                # where stdout is captured into build logs, and OCIR auth
+                # tokens are full credentials.
+                token_path = Path.home() / f".oci-ocir-token-{int(time.time())}.txt"
+                try:
+                    token_path.write_text(auth_token + "\n")
+                    os.chmod(token_path, 0o600)
+                    print(f"  Auth token created. Saved (mode 0600) to: {token_path}")
+                    print(f"  This is the only time we can show it — back it up before deleting.")
+                except OSError as e:
+                    # Filesystem unwritable — fall back to a masked notice and
+                    # require the user to re-fetch via the OCI Console.
+                    print(f"  Auth token created but could NOT be saved to disk ({e}).")
+                    print(f"  Delete it in the OCI Console and re-run, or paste it manually now.")
+                    auth_token = prompt("Paste the token you just created (or blank to abort)", secret=True)
+                    if not auth_token:
+                        sys.exit(1)
         else:
             auth_token = prompt("Paste existing OCIR auth token", secret=True)
 
@@ -479,9 +496,19 @@ def check_or_create_iam(cfg, create=False):
     policy_ok = False
     try:
         policies = identity.list_policies(cid).data
-        target = policy_statement.lower()
+        # Match either the OCID form (what we create programmatically) OR the
+        # name form (what users typically write when creating policies in the
+        # OCI Console, including the form we print in print_manual()).
+        # Both refer to the same DG, so either should count as 'already
+        # granted' and prevent a redundant create / spurious 'missing' error.
+        targets = (
+            build_statement(f"id {dg_ocid}").lower(),
+            build_statement(dg_name).lower(),
+            build_statement(f"'{dg_name}'").lower(),
+        )
         for p in policies:
-            if any(target in s.lower() for s in p.statements):
+            statements_lower = [s.lower() for s in p.statements]
+            if any(t in s for t in targets for s in statements_lower):
                 print(f"  Policy OK: {p.name} (already grants the required statement)")
                 policy_ok = True
                 break

--- a/ai/aidp_chat_client/web_ui/deploy.py
+++ b/ai/aidp_chat_client/web_ui/deploy.py
@@ -1,0 +1,858 @@
+#!/usr/bin/env python3
+"""
+deploy.py — Build, push, and deploy the AIDP Agent Chat UI to OCI Container Instances.
+
+Fully interactive: auto-discovers everything from ~/.oci/config, prompts for
+confirmation, creates missing resources (auth tokens, VCN, container instance).
+
+Prerequisites:
+  - Docker + Docker Buildx
+  - An OCI config at ~/.oci/config
+  - A deployed AIDP agent endpoint URL
+  - A Dynamic Group + Policy granting the deployed Container Instance permission
+    to invoke your agent endpoint (because AUTH = resource_principal in-container).
+    Example matching rule:
+        ALL {resource.type = 'computecontainerinstance', resource.compartment.id = '<COMPARTMENT_OCID>'}
+    Example policy:
+        Allow dynamic-group <DG_NAME> to use genai-agent-endpoint in compartment <COMPARTMENT_NAME>
+  - The Dynamic Group also added as a MEMBER of the AIDP Workbench that hosts
+    the agent (Workbench → Roles → Admin). IAM alone is not enough — the AIDP
+    gateway enforces its own Workbench auth and returns HTTP 404 on chat if
+    the resource principal isn't a workbench member.
+
+Usage:
+    python3 deploy.py                 # interactive; checks IAM, refuses if missing
+    python3 deploy.py --yes           # skip confirmations (uses defaults + env vars)
+    python3 deploy.py --create-iam    # also try to create the DG + Policy if missing
+                                      # (needs tenancy-level perms; falls back to manual)
+
+Run from the web_ui/ directory.
+"""
+
+import base64
+import os
+import subprocess
+import sys
+import time
+
+import oci
+from oci.regions import REGIONS_SHORT_NAMES
+
+_REGION_TO_SHORT = {v: k for k, v in REGIONS_SHORT_NAMES.items()}
+_AUTO = "--yes" in sys.argv
+_CREATE_IAM = "--create-iam" in sys.argv
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))           # web_ui/
+_BUILD_CONTEXT = os.path.dirname(_SCRIPT_DIR)                      # aidp_chat_client/
+_DOCKERFILE = os.path.join(_SCRIPT_DIR, "Dockerfile")
+_DEPLOY_CONFIG = os.path.join(_SCRIPT_DIR, "config-deploy.yaml")
+
+
+# ── Config loading ───────────────────────────────────────────────────
+
+def _load_deploy_config():
+    """Load config-deploy.yaml (sibling to deploy.py) if present, and bridge
+    its values to the env-var keys the rest of the script already reads from.
+    Existing env vars take precedence — letting users override the file at
+    invocation time without editing it. Falls through gracefully if the
+    file or PyYAML is missing."""
+    if not os.path.exists(_DEPLOY_CONFIG):
+        return
+    try:
+        import yaml
+    except ImportError:
+        print(f"  Note: config-deploy.yaml found but PyYAML isn't installed; ignoring it.")
+        print(f"        pip install pyyaml  # to enable")
+        return
+
+    with open(_DEPLOY_CONFIG) as f:
+        cfg = yaml.safe_load(f) or {}
+
+    # YAML key path → env-var name. Only set env if the YAML provides a
+    # non-empty value AND the env var isn't already set by the caller.
+    mapping = {
+        ("agent", "url"):                "AIDP_AGENT_URL",
+        ("deploy", "region"):            "OCI_REGION",
+        ("deploy", "compartment_id"):    "DEPLOY_COMPARTMENT_ID",
+        ("deploy", "display_name"):      "DEPLOY_DISPLAY_NAME",
+        ("deploy", "shape"):             "DEPLOY_SHAPE",
+        ("deploy", "cpus"):              "DEPLOY_CPUS",
+        ("deploy", "memory_gb"):         "DEPLOY_MEMORY_GB",
+        ("container", "repo"):           "OCIR_REPO",
+        ("container", "tag"):            "OCIR_TAG",
+        ("iam", "policy_resource"):      "AIDP_POLICY_RESOURCE",
+        ("ocir", "auth_token"):          "OCIR_AUTH_TOKEN",
+    }
+    applied = []
+    for path, env_key in mapping.items():
+        node = cfg
+        for p in path:
+            if not isinstance(node, dict):
+                node = None
+                break
+            node = node.get(p)
+        if node not in (None, "") and not os.environ.get(env_key):
+            os.environ[env_key] = str(node)
+            applied.append(env_key)
+
+    if applied:
+        print(f"  Loaded {len(applied)} value(s) from config-deploy.yaml: {', '.join(applied)}")
+
+
+_load_deploy_config()
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def prompt(label: str, default: str = "", secret: bool = False) -> str:
+    """Prompt user for input with a default value. Returns default if --yes."""
+    if _AUTO and default:
+        print(f"  {label}: {default}")
+        return default
+    suffix = f" [{default}]" if default else ""
+    if secret:
+        import getpass
+        val = getpass.getpass(f"  {label}{suffix}: ").strip()
+    else:
+        val = input(f"  {label}{suffix}: ").strip()
+    return val or default
+
+
+def run_cmd(cmd: list, input_data: str | None = None) -> None:
+    print(f"  $ {' '.join(cmd)}")
+    result = subprocess.run(cmd, input=input_data, text=True)
+    if result.returncode != 0:
+        print(f"  Command failed (exit code {result.returncode})")
+        sys.exit(result.returncode)
+
+
+def wait_for_state(get_fn, target_states, max_wait=300, poll_interval=10):
+    start = time.time()
+    while time.time() - start < max_wait:
+        resource = get_fn()
+        state = resource.data.lifecycle_state
+        print(f"    State: {state}")
+        if state in target_states:
+            return resource.data
+        if state in ("FAILED", "TERMINATED", "DELETED"):
+            raise RuntimeError(f"Resource entered {state} state")
+        time.sleep(poll_interval)
+    raise RuntimeError(f"Timed out waiting for state {target_states}")
+
+
+# ── Discovery ────────────────────────────────────────────────────────
+
+def discover_config():
+    """Auto-discover all config from ~/.oci/config + OCI APIs, prompt for the rest."""
+    print("\n── Configuration ──────────────────────────────────────────")
+    print("  Loading ~/.oci/config...")
+
+    oci_config = oci.config.from_file()
+    oci.config.validate_config(oci_config)
+
+    tenancy_id = os.environ.get("OCI_TENANCY_ID") or oci_config["tenancy"]
+    user_ocid = oci_config["user"]
+
+    print(f"  Tenancy: {tenancy_id}")
+    print(f"  User:    {user_ocid}")
+    # If region came from config-deploy.yaml or env, take it as-is.
+    # Only prompt when neither was set, falling back to ~/.oci/config region.
+    region = os.environ.get("OCI_REGION")
+    if not region:
+        region = prompt("Region (e.g. us-ashburn-1, sa-saopaulo-1, eu-frankfurt-1)", oci_config["region"])
+    print(f"  Region:  {region}")
+    # Propagate the choice so every regional OCI client (VCN, container,
+    # object storage) created below targets the selected region rather than
+    # whatever ~/.oci/config defaults to.
+    oci_config["region"] = region
+
+    # OCI Identity create/update/delete (auth tokens, dynamic groups, policies)
+    # MUST go through the tenancy's home region — other regions only host read
+    # replicas of identity resources. Discover the home region and pin the
+    # IdentityClient to it so IAM ops succeed even when deploying elsewhere.
+    bootstrap = oci.identity.IdentityClient(oci_config)
+    tenancy = bootstrap.get_tenancy(tenancy_id).data
+    # home_region_key is a short code like "IAD" / "GRU"; REGIONS_SHORT_NAMES
+    # maps short → full name (the inverse of _REGION_TO_SHORT, which we use
+    # elsewhere for region name → short code lookups).
+    home_region_key = tenancy.home_region_key.lower()
+    home_region = REGIONS_SHORT_NAMES.get(home_region_key)
+    if not home_region:
+        print(f"  ERROR: SDK does not recognize home region key {home_region_key!r}.")
+        print("         Update the oci package or set OCI_REGION to the home region manually.")
+        sys.exit(1)
+    tenancy_name = tenancy.name
+
+    oci_config_home = dict(oci_config)
+    oci_config_home["region"] = home_region
+    identity = oci.identity.IdentityClient(oci_config_home)
+
+    print(f"  Tenancy name: {tenancy_name}")
+    print(f"  Home region:  {home_region}  (used for auth tokens & IAM ops)")
+
+    region_key = _REGION_TO_SHORT.get(region)
+    if not region_key:
+        region_key = prompt("OCIR region key (e.g. iad, gru, fra)")
+    print(f"  Region key: {region_key}")
+
+    namespace = os.environ.get("OCIR_NAMESPACE")
+    if not namespace:
+        os_client = oci.object_storage.ObjectStorageClient(oci_config)
+        namespace = os_client.get_namespace().data
+    print(f"  OCIR namespace: {namespace}")
+
+    # OCIR username format depends on user type:
+    #  - IDCS-federated users (most modern tenancies): user.name already contains
+    #    "oracleidentitycloudservice/<email>" — prepend only the namespace.
+    #  - Local IAM users: user.name is bare — prepend namespace + IDCS prefix.
+    # Check for the embedded "/" to disambiguate.
+    username = os.environ.get("OCIR_USERNAME")
+    if not username:
+        user_data = identity.get_user(user_ocid).data
+        if "/" in user_data.name:
+            username = f"{namespace}/{user_data.name}"
+        else:
+            username = f"{namespace}/oracleidentitycloudservice/{user_data.name}"
+    print(f"  OCIR username: {username}")
+
+    auth_token = os.environ.get("OCIR_AUTH_TOKEN")
+    token_was_just_created = False
+    if not auth_token:
+        print("\n  OCIR Auth Token needed for Docker registry login.")
+        print("  Checking YOUR existing auth tokens (the API only lists this user's tokens)...")
+        tokens = identity.list_auth_tokens(user_ocid).data
+        active_tokens = [t for t in tokens if t.lifecycle_state == "ACTIVE"]
+        print(f"  Found {len(active_tokens)} of your active token(s) — OCI limit is 2 per user.")
+        for i, t in enumerate(active_tokens, 1):
+            desc = t.description or "(no description)"
+            created = t.time_created.strftime("%Y-%m-%d %H:%M") if t.time_created else "?"
+            print(f"    {i}) {desc} — created {created}")
+        if len(active_tokens) >= 2:
+            print("  Manage tokens at: Identity → Users → <your user> → Auth Tokens")
+
+        # In --yes mode with 2/2 tokens we refuse to silently delete an existing
+        # token — it might be in use by another tool (CI, backups, etc.) and
+        # rotating it without consent is destructive.
+        if len(active_tokens) >= 2 and _AUTO:
+            print()
+            print("  ERROR: 2/2 active OCIR auth tokens (OCI per-user limit reached).")
+            print("         Cannot safely create a new one in --yes mode without")
+            print("         risking another tool that depends on an existing token.")
+            print("         Resolve by either:")
+            print("           (a) Set OCIR_AUTH_TOKEN env var to a known token value, or")
+            print("           (b) Delete an unused token (OCI Console:")
+            print("               Identity → Users → your user → Auth Tokens),")
+            print("               then re-run.")
+            sys.exit(1)
+
+        choice = prompt("Create a new auth token? (y/n)", "y" if len(active_tokens) < 2 else "n")
+        if choice.lower() in ("y", "yes"):
+            if len(active_tokens) >= 2:
+                print("  You already have 2 active tokens (OCI limit).")
+                print("  Delete one first, or provide an existing token.")
+                auth_token = prompt("Paste existing OCIR auth token", secret=True)
+            else:
+                print("  Creating auth token...")
+                resp = identity.create_auth_token(
+                    oci.identity.models.CreateAuthTokenDetails(
+                        description="aidp-agent-chat-ui deploy"
+                    ),
+                    user_ocid,
+                )
+                auth_token = resp.data.token
+                token_was_just_created = True
+                print(f"  Auth token created. Save this — it won't be shown again!")
+                print(f"  Token: {auth_token}")
+        else:
+            auth_token = prompt("Paste existing OCIR auth token", secret=True)
+
+    if not auth_token:
+        print("ERROR: Auth token is required.")
+        sys.exit(1)
+
+    print("\n  Selecting compartment to deploy into...")
+    compartment_id = os.environ.get("DEPLOY_COMPARTMENT_ID")
+    if not compartment_id:
+        comps = identity.list_compartments(
+            tenancy_id, lifecycle_state="ACTIVE", access_level="ANY",
+            compartment_id_in_subtree=True, limit=500,
+        ).data
+        visible = 30
+        print(f"  Available compartments ({len(comps)} total):")
+        print(f"    0) {tenancy_name} (root)")
+        for i, c in enumerate(comps[:visible], 1):
+            print(f"    {i}) {c.name}")
+        if len(comps) > visible:
+            print(f"    ... and {len(comps) - visible} more — for those, paste the OCID directly below")
+
+        choice = prompt(
+            "Select compartment number, or paste a compartment/tenancy OCID",
+            "0",
+        ).strip()
+
+        if choice.startswith("ocid1.compartment.") or choice.startswith("ocid1.tenancy."):
+            compartment_id = choice
+        else:
+            try:
+                idx = int(choice)
+            except ValueError:
+                print(f"  Invalid input: {choice!r} is neither a number nor an OCID.")
+                sys.exit(1)
+            if idx == 0:
+                compartment_id = tenancy_id
+            elif 1 <= idx <= len(comps):
+                compartment_id = comps[idx - 1].id
+            else:
+                print(f"  Invalid selection: {idx} (must be 0–{len(comps)})")
+                sys.exit(1)
+    print(f"  Compartment: {compartment_id}")
+
+    # AIDP agent endpoint URL — copy from the AIDP console after deploying an agent.
+    agent_url = os.environ.get("AIDP_AGENT_URL")
+    if not agent_url:
+        agent_url = prompt(
+            "AIDP agent /chat URL (paste from AIDP console)",
+            "https://gateway.aidp.us-ashburn-1.oci.oraclecloud.com/agentendpoint/YOUR_AGENT_ID/chat",
+        )
+    print(f"  Agent URL: {agent_url}")
+
+    repo = os.environ.get("OCIR_REPO", "aidp-agent-chat-ui")
+    tag = os.environ.get("OCIR_TAG", "latest")
+    shape = os.environ.get("DEPLOY_SHAPE", "CI.Standard.E4.Flex")
+    cpus = os.environ.get("DEPLOY_CPUS", "1")
+    memory_gb = os.environ.get("DEPLOY_MEMORY_GB", "2")
+    display_name = os.environ.get("DEPLOY_DISPLAY_NAME", "aidp-agent-chat-ui")
+
+    ad = os.environ.get("DEPLOY_AD")
+    if not ad:
+        # Availability domains are regional — must query in the deploy region,
+        # not the home region where `identity` is pinned.
+        deploy_identity = oci.identity.IdentityClient(oci_config)
+        ad = deploy_identity.list_availability_domains(compartment_id).data[0].name
+
+    registry = f"{region_key}.ocir.io"
+    full_image = f"{registry}/{namespace}/{repo}:{tag}"
+
+    return {
+        "oci_config": oci_config,            # deploy region — for VCN, container, object storage
+        "oci_config_home": oci_config_home,  # home region — for Identity CRUD (auth tokens, DGs, policies)
+        "tenancy_id": tenancy_id,
+        "region": region,
+        "region_key": region_key,
+        "namespace": namespace,
+        "username": username,
+        "auth_token": auth_token,
+        "token_was_just_created": token_was_just_created,
+        "compartment_id": compartment_id,
+        "registry": registry,
+        "full_image": full_image,
+        "shape": shape,
+        "cpus": cpus,
+        "memory_gb": memory_gb,
+        "display_name": display_name,
+        "ad": ad,
+        "agent_url": agent_url,
+    }
+
+
+# ── IAM (Dynamic Group + Policy) ─────────────────────────────────────
+
+def check_or_create_iam(cfg, create=False):
+    """
+    Verify the Dynamic Group + Policy exist that let the deployed Container
+    Instance call the agent endpoint via resource principal.
+
+    With create=False (default) this is read-only — only `inspect` on identity
+    is needed. With create=True it tries to create whatever is missing,
+    falling back to printing manual instructions if perms or Identity Domains
+    get in the way.
+
+    Returns True if IAM is fully in place, False otherwise.
+    """
+    print("\n── Step 0: IAM check (Dynamic Group + Policy) ─────────────")
+
+    # Pin to home region — Identity create/update/delete on DGs and policies
+    # only works there.
+    identity = oci.identity.IdentityClient(cfg["oci_config_home"])
+    cid = cfg["compartment_id"]
+    name = cfg["display_name"]
+    dg_name = f"{name}-dg"
+    policy_name = f"{name}-policy"
+    matching_rule = (
+        f"ALL {{resource.type = 'computecontainerinstance', "
+        f"resource.compartment.id = '{cid}'}}"
+    )
+    # AIDP agent endpoints sit behind the AIDP Workbench gateway, which gates
+    # access via Workbench-level auth. The IAM family that controls Workbench
+    # access is 'ai-data-platforms'. Granting this is the IAM half of the
+    # equation — the principal STILL needs to be added as a member of the
+    # specific AIDP Workbench inside the AIDP UI (Workbench → Roles).
+    # Override via env var if Oracle changes the family name.
+    policy_resource = os.environ.get(
+        "AIDP_POLICY_RESOURCE", "ai-data-platforms"
+    )
+
+    # Will be filled in once the DG is confirmed/created. The OCID-based form
+    # works in both classic and Identity Domains tenancies; the bare-name form
+    # often fails to resolve in Identity Domains and produces the misleading
+    # "No permissions found" parser error.
+    dg_ocid = None
+
+    def build_statement(subject):
+        return (
+            f"Allow dynamic-group {subject} to use {policy_resource} "
+            f"in compartment id {cid}"
+        )
+
+    def print_manual():
+        # Manual instructions use the readable name form — the console resolves
+        # it correctly because it shows you a picker.
+        readable_statement = build_statement(dg_name)
+        print()
+        print("  Manual setup needed in the OCI Console BEFORE the container can call the agent:")
+        print()
+        print("  1. Identity → Dynamic Groups → Create:")
+        print(f"       Name:           {dg_name}")
+        print(f"       Matching rule:  {matching_rule}")
+        print()
+        print("  2. Identity → Policies → Create in your compartment:")
+        print(f"       Name:        {policy_name}")
+        print(f"       Statement:   {readable_statement}")
+        print()
+        print("  Note: tenancies using Identity Domains manage Dynamic Groups inside")
+        print("  the domain — use the Identity Domains console instead of classic IAM.")
+        print()
+        print(f"  Tip: if OCI rejects the resource type {policy_resource!r}, paste the")
+        print("       statement into the Console policy editor — it autocompletes valid")
+        print("       resource types. Re-run with: AIDP_POLICY_RESOURCE=<correct> python3 deploy.py")
+        print()
+        print("  After setup, re-run: python3 deploy.py")
+        print("  Or to auto-create now (needs tenancy admin): python3 deploy.py --create-iam")
+
+    # ── Dynamic Group ──
+    dg_ok = False
+    try:
+        dgs = identity.list_dynamic_groups(cfg["tenancy_id"]).data
+        existing_dg = next(
+            (d for d in dgs if d.name == dg_name and d.lifecycle_state == "ACTIVE"),
+            None,
+        )
+        if existing_dg:
+            print(f"  Dynamic Group OK: {existing_dg.name}")
+            dg_ok = True
+            dg_ocid = existing_dg.id
+        else:
+            print(f"  Dynamic Group missing: {dg_name}")
+    except oci.exceptions.ServiceError as e:
+        print(f"  Cannot list Dynamic Groups ({e.code}). Skipping check.")
+        print_manual()
+        return False
+
+    if not dg_ok and create:
+        try:
+            print(f"  → Creating Dynamic Group: {dg_name}")
+            resp = identity.create_dynamic_group(
+                oci.identity.models.CreateDynamicGroupDetails(
+                    compartment_id=cfg["tenancy_id"],
+                    name=dg_name,
+                    matching_rule=matching_rule,
+                    description=f"For {name} Container Instance to call AIDP agents",
+                )
+            )
+            dg_ok = True
+            dg_ocid = resp.data.id
+            print("    Created.")
+        except oci.exceptions.ServiceError as e:
+            print(f"    Could not create Dynamic Group: {e.code} — {e.message}")
+            print_manual()
+            return False
+
+    if not dg_ok:
+        print_manual()
+        return False
+
+    # Use the OCID form for programmatic statement creation — robust against
+    # Identity Domains and against newly-created DGs whose name hasn't propagated.
+    policy_statement = build_statement(f"id {dg_ocid}")
+
+    # ── Policy ──
+    policy_ok = False
+    try:
+        policies = identity.list_policies(cid).data
+        target = policy_statement.lower()
+        for p in policies:
+            if any(target in s.lower() for s in p.statements):
+                print(f"  Policy OK: {p.name} (already grants the required statement)")
+                policy_ok = True
+                break
+        if not policy_ok:
+            print(f"  Policy missing: no policy in this compartment grants the required access")
+    except oci.exceptions.ServiceError as e:
+        print(f"  Cannot list Policies ({e.code}). Skipping check.")
+        print_manual()
+        return False
+
+    if not policy_ok and create:
+        try:
+            existing_named = next(
+                (p for p in policies if p.name == policy_name), None
+            )
+            if existing_named:
+                print(f"  → Policy '{policy_name}' exists; appending statement")
+                identity.update_policy(
+                    existing_named.id,
+                    oci.identity.models.UpdatePolicyDetails(
+                        statements=list(existing_named.statements) + [policy_statement],
+                    ),
+                )
+            else:
+                print(f"  → Creating Policy: {policy_name}")
+                identity.create_policy(
+                    oci.identity.models.CreatePolicyDetails(
+                        compartment_id=cid,
+                        name=policy_name,
+                        description=f"Grants {dg_name} access to AIDP agent endpoints",
+                        statements=[policy_statement],
+                    )
+                )
+            policy_ok = True
+            print("    Done.")
+        except oci.exceptions.ServiceError as e:
+            print(f"    Could not create/update Policy: {e.code} — {e.message}")
+            if "no permissions found" in (e.message or "").lower():
+                print()
+                print("    OCI's parser couldn't resolve any permissions in this statement —")
+                print("    the most common cause is the resource family name being wrong.")
+                print(f"    Statement attempted:")
+                print(f"      {policy_statement}")
+                print()
+                print("    Paste it into the OCI Console policy editor (Identity → Policies →")
+                print("    Create) — it will autocomplete valid resource family names. Then")
+                print(f"    re-run with: AIDP_POLICY_RESOURCE=<the right one> python3 deploy.py --create-iam")
+            print_manual()
+            return False
+
+    if not policy_ok:
+        print_manual()
+        return False
+
+    print("  IAM is in place.")
+    # Stash the DG OCID for the final post-deploy reminder.
+    cfg["dg_ocid"] = dg_ocid
+    return True
+
+
+# ── Docker build & push ──────────────────────────────────────────────
+
+def _docker_login_with_retry(cfg, max_wait_seconds: int = 90, interval: int = 5) -> None:
+    """Try `docker login`, retrying briefly on Unauthorized.
+
+    Newly-created OCIR auth tokens take ~30-60s to propagate, so an immediate
+    login using a fresh token returns 401. Retrying with a short backoff is
+    safe and sidesteps the race. We `docker logout` before each attempt
+    because Rancher Desktop's credential cache can hold a stale entry that
+    makes valid tokens appear unauthorized.
+
+    Login uses `-p` instead of `--password-stdin` because Rancher Desktop's
+    Docker CLI mishandles stdin from subprocess. The token never leaves the
+    process — the CLI warning about ps/history visibility is not a concern.
+    """
+    deadline = time.time() + max_wait_seconds
+    attempt = 1
+    while True:
+        subprocess.run(["docker", "logout", cfg["registry"]],
+                       capture_output=True, check=False)
+        result = subprocess.run(
+            ["docker", "login", cfg["registry"],
+             "--username", cfg["username"], "-p", cfg["auth_token"]],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            if attempt > 1:
+                print(f"  Login succeeded on attempt {attempt}.")
+            else:
+                print("  Login succeeded.")
+            return
+        if time.time() >= deadline:
+            print(f"  Docker login still failing after {max_wait_seconds}s.")
+            print(f"  stderr: {(result.stderr or '').strip()[:300]}")
+            sys.exit(1)
+        is_propagation = (cfg.get("token_was_just_created") and
+                          "unauthorized" in (result.stderr or "").lower())
+        reason = ("token still propagating" if is_propagation
+                  else (result.stderr or "").strip().splitlines()[-1][:120])
+        print(f"  Attempt {attempt} failed ({reason}). Retrying in {interval}s...")
+        time.sleep(interval)
+        attempt += 1
+
+
+def build_and_push(cfg):
+    print("\n── Step 1: Build & Push Docker Image ──────────────────────")
+    print(f"  Image: {cfg['full_image']}")
+
+    print("\n→ Logging in to OCIR...")
+    _docker_login_with_retry(cfg)
+
+    # Build context is aidp_chat_client/ so the Dockerfile can install the
+    # parent library alongside the web_ui sources.
+    print("\n→ Building image (linux/amd64)...")
+    run_cmd([
+        "docker", "buildx", "build",
+        "--platform", "linux/amd64",
+        "-t", cfg["full_image"],
+        "-f", _DOCKERFILE,
+        _BUILD_CONTEXT,
+    ])
+
+    print("\n→ Pushing image...")
+    run_cmd(["docker", "push", cfg["full_image"]])
+    print("  Image pushed.")
+
+
+# ── Networking ───────────────────────────────────────────────────────
+
+def _find_or_create(list_fn, create_fn, wait_get_fn, label):
+    """Generic find-or-create with AVAILABLE wait."""
+    existing = list_fn()
+    active = [r for r in existing if r.lifecycle_state == "AVAILABLE"]
+    if active:
+        print(f"  {label} exists: {active[0].id}")
+        return active[0]
+    print(f"  Creating {label}...")
+    resp = create_fn()
+    result = wait_for_state(lambda: wait_get_fn(resp.data.id), ["AVAILABLE"])
+    print(f"  {label} created: {result.id}")
+    return result
+
+
+def setup_networking(cfg):
+    print("\n── Step 2: Networking ──────────────────────────────────────")
+    vn = oci.core.VirtualNetworkClient(cfg["oci_config"])
+    cid = cfg["compartment_id"]
+    name = cfg["display_name"]
+
+    vcn = _find_or_create(
+        lambda: vn.list_vcns(cid, display_name=f"{name}-vcn").data,
+        lambda: vn.create_vcn(oci.core.models.CreateVcnDetails(
+            compartment_id=cid, display_name=f"{name}-vcn",
+            cidr_blocks=["10.0.0.0/16"], dns_label="agentchat",
+        )),
+        lambda id: vn.get_vcn(id),
+        "VCN",
+    )
+
+    igw = _find_or_create(
+        lambda: vn.list_internet_gateways(cid, vcn_id=vcn.id, display_name=f"{name}-igw").data,
+        lambda: vn.create_internet_gateway(oci.core.models.CreateInternetGatewayDetails(
+            compartment_id=cid, vcn_id=vcn.id, display_name=f"{name}-igw", is_enabled=True,
+        )),
+        lambda id: vn.get_internet_gateway(id),
+        "Internet Gateway",
+    )
+
+    rt = _find_or_create(
+        lambda: vn.list_route_tables(cid, vcn_id=vcn.id, display_name=f"{name}-rt").data,
+        lambda: vn.create_route_table(oci.core.models.CreateRouteTableDetails(
+            compartment_id=cid, vcn_id=vcn.id, display_name=f"{name}-rt",
+            route_rules=[oci.core.models.RouteRule(
+                network_entity_id=igw.id, destination="0.0.0.0/0", destination_type="CIDR_BLOCK",
+            )],
+        )),
+        lambda id: vn.get_route_table(id),
+        "Route Table",
+    )
+
+    sl = _find_or_create(
+        lambda: vn.list_security_lists(cid, vcn_id=vcn.id, display_name=f"{name}-sl").data,
+        lambda: vn.create_security_list(oci.core.models.CreateSecurityListDetails(
+            compartment_id=cid, vcn_id=vcn.id, display_name=f"{name}-sl",
+            ingress_security_rules=[
+                oci.core.models.IngressSecurityRule(
+                    source="0.0.0.0/0", source_type="CIDR_BLOCK", protocol="6",
+                    tcp_options=oci.core.models.TcpOptions(
+                        destination_port_range=oci.core.models.PortRange(min=5001, max=5001)),
+                ),
+            ],
+            egress_security_rules=[
+                oci.core.models.EgressSecurityRule(
+                    destination="0.0.0.0/0", destination_type="CIDR_BLOCK", protocol="all",
+                ),
+            ],
+        )),
+        lambda id: vn.get_security_list(id),
+        "Security List",
+    )
+
+    subnet = _find_or_create(
+        lambda: vn.list_subnets(cid, vcn_id=vcn.id, display_name=f"{name}-subnet").data,
+        lambda: vn.create_subnet(oci.core.models.CreateSubnetDetails(
+            compartment_id=cid, vcn_id=vcn.id, display_name=f"{name}-subnet",
+            cidr_block="10.0.1.0/24", route_table_id=rt.id,
+            security_list_ids=[sl.id], dns_label="chatsub",
+            prohibit_public_ip_on_vnic=False,
+        )),
+        lambda id: vn.get_subnet(id),
+        "Subnet",
+    )
+
+    return subnet.id
+
+
+# ── Container Instance ───────────────────────────────────────────────
+
+def deploy_container(cfg, subnet_id):
+    print("\n── Step 3: Container Instance ──────────────────────────────")
+    ci = oci.container_instances.ContainerInstanceClient(cfg["oci_config"])
+    cid = cfg["compartment_id"]
+    name = cfg["display_name"]
+
+    existing = ci.list_container_instances(cid, display_name=name).data.items
+    active = [i for i in existing if i.lifecycle_state in ("ACTIVE", "CREATING", "UPDATING")]
+    if active:
+        print(f"  Replacing existing instance: {active[0].id}")
+        ci.delete_container_instance(active[0].id)
+        try:
+            wait_for_state(
+                lambda: ci.get_container_instance(active[0].id),
+                ["DELETED"], max_wait=120,
+            )
+        except Exception:
+            pass
+
+    print(f"  Creating container instance...")
+    print(f"    Shape: {cfg['shape']} ({cfg['cpus']} OCPU, {cfg['memory_gb']} GB)")
+    print(f"    Image: {cfg['full_image']}")
+
+    resp = ci.create_container_instance(
+        oci.container_instances.models.CreateContainerInstanceDetails(
+            display_name=name,
+            compartment_id=cid,
+            availability_domain=cfg["ad"],
+            shape=cfg["shape"],
+            shape_config=oci.container_instances.models.CreateContainerInstanceShapeConfigDetails(
+                ocpus=float(cfg["cpus"]),
+                memory_in_gbs=float(cfg["memory_gb"]),
+            ),
+            containers=[
+                oci.container_instances.models.CreateContainerDetails(
+                    display_name=f"{name}-app",
+                    image_url=cfg["full_image"],
+                    environment_variables={
+                        "AIDP_AGENT_URL": cfg["agent_url"],
+                        "AIDP_AUTH": "resource_principal",
+                        "OCI_REGION": cfg["region"],
+                    },
+                )
+            ],
+            vnics=[
+                oci.container_instances.models.CreateContainerVnicDetails(
+                    subnet_id=subnet_id,
+                    is_public_ip_assigned=True,
+                )
+            ],
+            image_pull_secrets=[
+                oci.container_instances.models.CreateBasicImagePullSecretDetails(
+                    registry_endpoint=cfg["registry"],
+                    secret_type="BASIC",
+                    # OCI requires BASIC pull-secret credentials base64-encoded.
+                    username=base64.b64encode(cfg["username"].encode()).decode(),
+                    password=base64.b64encode(cfg["auth_token"].encode()).decode(),
+                )
+            ],
+            container_restart_policy="ALWAYS",
+        )
+    )
+
+    print("  Waiting for ACTIVE state...")
+    instance = wait_for_state(
+        lambda: ci.get_container_instance(resp.data.id),
+        ["ACTIVE"], max_wait=600, poll_interval=15,
+    )
+    return instance
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+def main():
+    print("=" * 60)
+    print("  AIDP Agent Chat UI  |  Deploy to OCI Container Instances")
+    print("=" * 60)
+
+    cfg = discover_config()
+
+    if not check_or_create_iam(cfg, create=_CREATE_IAM):
+        print("\n  Aborting — set up the Dynamic Group + Policy and re-run.")
+        sys.exit(1)
+
+    print(f"""
+── Summary ────────────────────────────────────────────────
+  Region:        {cfg['region']} ({cfg['region_key']})
+  Compartment:   {cfg['compartment_id']}
+  Image:         {cfg['full_image']}
+  Shape:         {cfg['shape']} ({cfg['cpus']} OCPU, {cfg['memory_gb']} GB)
+  AD:            {cfg['ad']}
+  Display Name:  {cfg['display_name']}
+  Agent URL:     {cfg['agent_url']}
+""")
+
+    if not _AUTO:
+        confirm = input("  Proceed? [Y/n] ").strip().lower()
+        if confirm in ("n", "no"):
+            print("  Cancelled.")
+            sys.exit(0)
+
+    build_and_push(cfg)
+    subnet_id = setup_networking(cfg)
+    instance = deploy_container(cfg, subnet_id)
+
+    print("\n── Done ───────────────────────────────────────────────────")
+
+    def _print_workbench_reminder():
+        dg = cfg.get("dg_ocid", "<your dynamic group OCID>")
+        print("""
+  ┌─ ONE MORE STEP ─ AIDP Workbench membership ─────────────────────────┐
+  │                                                                     │
+  │  IAM alone is not enough. The AIDP gateway also enforces            │
+  │  Workbench-level auth — the deployed Container Instance's resource  │
+  │  principal must be a MEMBER of the AIDP Workbench that hosts your   │
+  │  agent. Without this, the chat UI will get HTTP 404 from the        │
+  │  gateway even though IAM is correctly set up.                       │
+  │                                                                     │
+  │  How to add it:                                                     │
+  │    1. Open the AIDP Workbench that hosts your agent                 │
+  │    2. Go to the Roles tab in the left menu                          │
+  │    3. Add the dynamic-group OCID below as Admin (simplest role)     │
+  │                                                                     │""")
+        print(f"  │  DG OCID:")
+        print(f"  │    {dg}")
+        print("""  │                                                                     │
+  └─────────────────────────────────────────────────────────────────────┘
+""")
+
+    try:
+        vn = oci.core.VirtualNetworkClient(cfg["oci_config"])
+        ci = oci.container_instances.ContainerInstanceClient(cfg["oci_config"])
+        full = ci.get_container_instance(instance.id).data
+        for vnic_info in (full.vnics or []):
+            vnic = vn.get_vnic(vnic_info.vnic_id).data
+            if vnic.public_ip:
+                print(f"""
+  Container instance is running!
+
+  Public IP:  {vnic.public_ip}
+  Access at:  http://{vnic.public_ip}:5001
+
+  Note: this is HTTP, not HTTPS, and the proxy has no auth in front of it.
+  For production, place a load balancer with HTTPS + user auth in front.
+""")
+                _print_workbench_reminder()
+                return
+    except Exception:
+        pass
+    print(f"\n  Container instance created: {instance.id}")
+    print("  Check OCI Console for the public IP.")
+    _print_workbench_reminder()
+
+
+if __name__ == "__main__":
+    main()

--- a/ai/aidp_chat_client/web_ui/index.html
+++ b/ai/aidp_chat_client/web_ui/index.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>AIDP Agent Chat</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: #f4f6f9;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+
+    header {
+      background: #c74634;
+      color: white;
+      padding: 16px 24px;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: 0.3px;
+    }
+
+    header span {
+      font-weight: 300;
+      font-size: 14px;
+      margin-left: 12px;
+      opacity: 0.8;
+    }
+
+    #chat-window {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .message {
+      max-width: 75%;
+      padding: 12px 16px;
+      border-radius: 12px;
+      font-size: 14px;
+      line-height: 1.6;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+
+    .message.user {
+      align-self: flex-end;
+      background: #c74634;
+      color: white;
+      border-bottom-right-radius: 4px;
+    }
+
+    .message.agent {
+      align-self: flex-start;
+      background: white;
+      color: #1a1a1a;
+      border-bottom-left-radius: 4px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+    }
+
+    .message.agent.thinking {
+      color: #888;
+      font-style: italic;
+    }
+
+    /* Markdown styling for agent messages */
+    .message.agent.rendered { white-space: normal; }
+    .message.agent p { margin: 0 0 8px 0; }
+    .message.agent p:last-child { margin-bottom: 0; }
+    .message.agent ul, .message.agent ol { margin: 4px 0 8px 22px; padding: 0; }
+    .message.agent li { margin: 2px 0; }
+    .message.agent code {
+      background: #f0f2f5;
+      padding: 1px 5px;
+      border-radius: 4px;
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 13px;
+    }
+    .message.agent pre {
+      background: #f0f2f5;
+      padding: 10px 12px;
+      border-radius: 6px;
+      overflow-x: auto;
+      margin: 6px 0;
+    }
+    .message.agent pre code {
+      background: none;
+      padding: 0;
+      font-size: 12.5px;
+    }
+    .message.agent a { color: #0a66c2; text-decoration: underline; }
+    .message.agent blockquote {
+      border-left: 3px solid #d0d0d0;
+      margin: 6px 0;
+      padding: 2px 10px;
+      color: #555;
+    }
+    .message.agent h1, .message.agent h2, .message.agent h3 {
+      margin: 10px 0 6px 0;
+      font-weight: 600;
+    }
+    .message.agent h1 { font-size: 17px; }
+    .message.agent h2 { font-size: 15px; }
+    .message.agent h3 { font-size: 14px; }
+    .message.agent table { border-collapse: collapse; margin: 6px 0; }
+    .message.agent th, .message.agent td {
+      border: 1px solid #d0d0d0;
+      padding: 4px 8px;
+      text-align: left;
+    }
+    .message.agent hr {
+      border: none;
+      border-top: 1px solid #e0e0e0;
+      margin: 10px 0;
+    }
+
+    #input-area {
+      display: flex;
+      gap: 10px;
+      padding: 16px 24px;
+      background: white;
+      border-top: 1px solid #e0e0e0;
+    }
+
+    #user-input {
+      flex: 1;
+      padding: 10px 14px;
+      border: 1px solid #d0d0d0;
+      border-radius: 8px;
+      font-size: 14px;
+      outline: none;
+      resize: none;
+      height: 44px;
+      font-family: inherit;
+    }
+
+    #user-input:focus {
+      border-color: #c74634;
+    }
+
+    #send-btn {
+      padding: 10px 20px;
+      background: #c74634;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      font-size: 14px;
+      cursor: pointer;
+      font-weight: 500;
+    }
+
+    #send-btn:hover { background: #a83828; }
+    #send-btn:disabled { background: #ccc; cursor: not-allowed; }
+
+    .session-id {
+      font-size: 11px;
+      color: #aaa;
+      text-align: center;
+      padding: 4px;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  AIDP Agent Chat
+  <span>Streaming chat over a deployed agent endpoint</span>
+</header>
+
+<div id="chat-window"></div>
+
+<div class="session-id" id="session-label"></div>
+
+<div id="input-area">
+  <textarea id="user-input" placeholder="Type your message..."></textarea>
+  <button id="send-btn" onclick="sendMessage()">Send</button>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+<script>
+  // CDN scripts (marked / DOMPurify) may fail to load — fall back to plain
+  // text rendering rather than letting setOptions throw and break the page.
+  const _hasMd = typeof marked !== "undefined" && typeof DOMPurify !== "undefined";
+  if (_hasMd) marked.setOptions({ breaks: true, gfm: true });
+
+  function renderMarkdown(text) {
+    if (!_hasMd) {
+      return text
+        .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+        .replace(/\n/g, "<br>");
+    }
+    return DOMPurify.sanitize(marked.parse(text));
+  }
+
+  // The AIDP gateway threads conversation memory by session_id — a stable
+  // UUID is generated per browser tab and sent on every turn.
+  // crypto.randomUUID() needs a secure context (HTTPS) — fall back when
+  // the page is served over plain HTTP (e.g. Container Instance public IP).
+  function makeUUID() {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === "x" ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
+  const SESSION_ID = makeUUID();
+  document.getElementById("session-label").textContent = `Session: ${SESSION_ID}`;
+
+  const chatWindow = document.getElementById("chat-window");
+  const input = document.getElementById("user-input");
+  const sendBtn = document.getElementById("send-btn");
+
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+
+  function appendMessage(role, text, id) {
+    const div = document.createElement("div");
+    div.className = `message ${role}`;
+    if (id) div.id = id;
+    div.textContent = text;
+    chatWindow.appendChild(div);
+    chatWindow.scrollTop = chatWindow.scrollHeight;
+    return div;
+  }
+
+  async function sendMessage() {
+    const text = input.value.trim();
+    if (!text) return;
+
+    input.value = "";
+    sendBtn.disabled = true;
+
+    appendMessage("user", text);
+    const agentMsgId = "agent-" + Date.now();
+    const agentMsg = appendMessage("agent thinking", "Thinking...", agentMsgId);
+
+    try {
+      const response = await fetch("/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          message: text,
+          session_id: SESSION_ID,
+        })
+      });
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let fullText = "";
+      let started = false;
+      let streaming = true;
+      // Carry-over buffer for SSE lines that get split across network reads.
+      // Without this, long responses (e.g. tool-calling chains) lose data
+      // when the JSON of a single `data:` line spans two TCP chunks.
+      let buffer = "";
+
+      while (streaming) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Split off complete lines; the last element may be a partial line
+        // that we hold over for the next read.
+        const parts = buffer.split(/\r?\n/);
+        buffer = parts.pop();
+        const lines = parts;
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue;
+          const raw = line.slice(6).trim();
+          if (!raw) continue;
+
+          if (raw === "[DONE]") { streaming = false; break; }
+
+          try {
+            const parsed = JSON.parse(raw);
+
+            if (parsed?.error) {
+              agentMsg.textContent = "Error: " + parsed.error;
+              agentMsg.classList.remove("thinking");
+              streaming = false;
+              break;
+            }
+
+            // Pick text from any output event that has output_text content
+            const output = parsed?.response?.output;
+            if (Array.isArray(output)) {
+              for (const out of output) {
+                if (Array.isArray(out?.content)) {
+                  for (const c of out.content) {
+                    if (c?.type === "output_text" && c?.text) {
+                      agentMsg.classList.remove("thinking");
+                      agentMsg.classList.add("rendered");
+                      agentMsg.innerHTML = renderMarkdown(c.text);
+                      fullText = c.text;
+                      started = true;
+                      chatWindow.scrollTop = chatWindow.scrollHeight;
+                    }
+                  }
+                }
+              }
+            }
+
+          } catch (_) {
+            // non-JSON SSE lines, skip
+          }
+        }
+      }
+
+      reader.cancel();
+
+      if (!started) {
+        agentMsg.textContent = "No response received.";
+        agentMsg.classList.remove("thinking");
+      }
+
+    } catch (err) {
+      agentMsg.textContent = "Connection error: " + err.message;
+      agentMsg.classList.remove("thinking");
+    }
+
+    sendBtn.disabled = false;
+    input.focus();
+  }
+</script>
+
+</body>
+</html>

--- a/ai/aidp_chat_client/web_ui/requirements.txt
+++ b/ai/aidp_chat_client/web_ui/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+flask-cors>=4.0

--- a/ai/aidp_chat_client/web_ui/server.py
+++ b/ai/aidp_chat_client/web_ui/server.py
@@ -16,6 +16,8 @@ Usage:
     # then open http://localhost:5001
 """
 
+import json
+import logging
 import os
 import oci
 import requests
@@ -24,6 +26,12 @@ from flask_cors import CORS
 
 from aidp_chat_client import AIDPChatClient
 from aidp_chat_client.config import load_oci_config
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 # ── Configuration ────────────────────────────────────────────────────────────
 # Edit these for local dev. When deployed via deploy.py, AIDP_AGENT_URL and
@@ -68,7 +76,7 @@ def index():
 @app.route("/chat", methods=["POST"])
 def chat():
     data = request.get_json() or {}
-    print(f"[chat] session_id from browser: {data.get('session_id')!r}")
+    logger.info("session_id from browser: %r", data.get("session_id"))
     payload = {
         "isStreamEnabled": True,
         "input": [
@@ -87,7 +95,7 @@ def chat():
 
     def generate():
         try:
-            print(f"[chat] entering generator; calling AIDP", flush=True)
+            logger.info("entering generator; calling AIDP")
             with requests.post(
                 AGENT_URL,
                 json=payload,
@@ -99,29 +107,33 @@ def chat():
                 },
                 timeout=120,
             ) as response:
-                print(f"[chat] AIDP status={response.status_code} "
-                      f"content-type={response.headers.get('content-type')} "
-                      f"opc-request-id={response.headers.get('opc-request-id')}",
-                      flush=True)
+                logger.info(
+                    "AIDP status=%s content-type=%s opc-request-id=%s",
+                    response.status_code,
+                    response.headers.get("content-type"),
+                    response.headers.get("opc-request-id"),
+                )
                 response.raise_for_status()
                 line_count = 0
                 for line in response.iter_lines():
                     if line:
                         line_count += 1
                         if line_count <= 3:
-                            print(f"[chat] line {line_count}: {line.decode('utf-8')[:200]}",
-                                  flush=True)
+                            logger.info(
+                                "line %d: %s",
+                                line_count,
+                                line.decode("utf-8")[:200],
+                            )
                         yield f"{line.decode('utf-8')}\n\n"
-                print(f"[chat] stream finished — {line_count} non-empty lines yielded",
-                      flush=True)
+                logger.info("stream finished — %d non-empty lines yielded", line_count)
         except Exception as e:
-            print(f"[ERROR] {e}", flush=True)
-            yield f'data: {{"error": "{e}"}}\n\n'
+            logger.exception("chat stream failed")
+            yield f"data: {json.dumps({'error': str(e)})}\n\n"
 
     return Response(generate(), mimetype="text/event-stream")
 
 
 if __name__ == "__main__":
-    print(f"AIDP Agent Chat proxy -> {AGENT_URL}")
-    print("Open http://localhost:5001 in your browser")
+    logger.info("AIDP Agent Chat proxy -> %s", AGENT_URL)
+    logger.info("Open http://localhost:5001 in your browser")
     app.run(host="0.0.0.0", port=5001, debug=False)

--- a/ai/aidp_chat_client/web_ui/server.py
+++ b/ai/aidp_chat_client/web_ui/server.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Local proxy that puts a browser UI in front of a deployed AIDP agent endpoint.
+
+OCI request signing cannot run safely in the browser, so this Flask app loads
+your local OCI credentials, signs each request, and streams the agent's SSE
+response back to the browser unchanged.
+
+Reuses AIDPChatClient from the parent library to construct the signer.
+
+Usage:
+    python3 -m pip install -e ..               # install the parent aidp_chat_client library
+    python3 -m pip install -r requirements.txt
+    # edit AGENT_URL below, then:
+    python3 server.py
+    # then open http://localhost:5001
+"""
+
+import os
+import oci
+import requests
+from flask import Flask, request, Response, send_from_directory
+from flask_cors import CORS
+
+from aidp_chat_client import AIDPChatClient
+from aidp_chat_client.config import load_oci_config
+
+# ── Configuration ────────────────────────────────────────────────────────────
+# Edit these for local dev. When deployed via deploy.py, AIDP_AGENT_URL and
+# AIDP_AUTH are injected as container env vars and override these constants.
+AGENT_URL = os.environ.get("AIDP_AGENT_URL") or \
+    "https://gateway.aidp.<region>.oci.oraclecloud.com/agentendpoint/<AGENT_ID>/chat"
+OCI_CONFIG_PATH = None       # None → ~/.oci/config (unused when AUTH == "resource_principal")
+OCI_PROFILE = "DEFAULT"
+AUTH = os.environ.get("AIDP_AUTH", "api_key")  # "api_key", "security_token", or "resource_principal"
+
+if AUTH == "resource_principal":
+    # Resource principal signers auto-refresh in theory but can serve stale
+    # tokens once the underlying federation token expires (typically every
+    # few hours). To stay robust on long-running deployments we build a
+    # fresh signer per request via get_signer() below — the metadata service
+    # call is cheap (a few ms) and avoids the "container running for hours
+    # then 401s on every request" failure mode.
+    _cached_signer = None
+else:
+    config = load_oci_config(OCI_CONFIG_PATH, OCI_PROFILE)
+    _cached_signer = AIDPChatClient(AGENT_URL, config, auth=AUTH).signer
+
+
+def get_signer():
+    if AUTH == "resource_principal":
+        return oci.auth.signers.get_resource_principals_signer()
+    return _cached_signer
+
+app = Flask(__name__, static_folder=".")
+CORS(app)
+
+
+@app.route("/")
+def index():
+    response = send_from_directory(".", "index.html")
+    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    return response
+
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    data = request.get_json() or {}
+    print(f"[chat] session_id from browser: {data.get('session_id')!r}")
+    payload = {
+        "isStreamEnabled": True,
+        "input": [
+            {
+                "role": "user",
+                "content": [{"type": "INPUT_TEXT", "text": data.get("message", "")}],
+            }
+        ],
+        "session_id": data.get("session_id"),
+    }
+
+    # The gateway threads conversation memory by the x-session-id header,
+    # not the session_id field in the body. Send both, matching what the
+    # AIDP console does (verified via HAR capture).
+    session_id = data.get("session_id") or ""
+
+    def generate():
+        try:
+            print(f"[chat] entering generator; calling AIDP", flush=True)
+            with requests.post(
+                AGENT_URL,
+                json=payload,
+                auth=get_signer(),
+                stream=True,
+                headers={
+                    "Content-Type": "application/json",
+                    "x-session-id": session_id,
+                },
+                timeout=120,
+            ) as response:
+                print(f"[chat] AIDP status={response.status_code} "
+                      f"content-type={response.headers.get('content-type')} "
+                      f"opc-request-id={response.headers.get('opc-request-id')}",
+                      flush=True)
+                response.raise_for_status()
+                line_count = 0
+                for line in response.iter_lines():
+                    if line:
+                        line_count += 1
+                        if line_count <= 3:
+                            print(f"[chat] line {line_count}: {line.decode('utf-8')[:200]}",
+                                  flush=True)
+                        yield f"{line.decode('utf-8')}\n\n"
+                print(f"[chat] stream finished — {line_count} non-empty lines yielded",
+                      flush=True)
+        except Exception as e:
+            print(f"[ERROR] {e}", flush=True)
+            yield f'data: {{"error": "{e}"}}\n\n'
+
+    return Response(generate(), mimetype="text/event-stream")
+
+
+if __name__ == "__main__":
+    print(f"AIDP Agent Chat proxy -> {AGENT_URL}")
+    print("Open http://localhost:5001 in your browser")
+    app.run(host="0.0.0.0", port=5001, debug=False)


### PR DESCRIPTION
# Description

Adds a minimal browser chat UI for any deployed AIDP agent endpoint, under `ai/aidp_chat_client/web_ui/`. The browser cannot safely sign OCI requests, so a small Flask proxy holds OCI credentials, signs every request to the agent gateway, and streams the SSE response back to a single-page HTML frontend.

The sample is intentionally complete enough to run two ways:
- **Local development** — `python3 server.py` on your laptop, signing as your OCI user from `~/.oci/config`.
- **Cloud deployment** — `python3 deploy.py` builds the Docker image, pushes to OCIR, provisions a VCN + Container Instance with port 5001 open, and configures the IAM Dynamic Group + Policy needed for the container's resource principal to invoke the agent. A `config-deploy.yaml` lets users skip prompts; a sample template is included.

The README documents the **two layers of identity setup** required for resource-principal access: an OCI IAM policy (`use ai-data-platforms`) and AIDP Workbench membership for the dynamic group. The latter is a non-obvious gotcha — without it, the gateway returns HTTP 404 even though IAM is correctly set up.

A small change to `ai/aidp_chat_client/setup.py` (replacing `find_packages()` with explicit `packages=["aidp_chat_client"]` + `package_dir={"aidp_chat_client": "."}`) is included so the library installs correctly inside the Docker build context. The previous `find_packages()` call returned an empty list because of the project's flat layout, which silently broke non-editable installs; editable installs (the common local-dev path) continue to work unchanged.

**Dependencies (added per-sample, not to the repo at large):**
- `flask`, `flask-cors` — already in `web_ui/requirements.txt`
- `oci`, `requests` — already pulled in by the parent `aidp_chat_client` library
- `pyyaml` (only for `deploy.py` to read the optional `config-deploy.yaml`)

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

End-to-end tested against a deployed AIDP agent endpoint.

- [x] Local mode: `python3 server.py` from the `web_ui/` folder, opened `http://localhost:5001`, sent chat messages, verified streaming responses appear in the browser.
- [x] Cloud mode: ran `python3 deploy.py --create-iam`, verified the Container Instance came up, opened the public IP on port 5001, sent chat messages, verified streaming responses.
- [x] IAM verification: confirmed the auto-generated Dynamic Group + Policy works once the dynamic group is also added to the AIDP Workbench under Roles → Admin (this manual step is documented in the README).
- [x] Library install: `pip install .` (non-editable) and `pip install -e .` (editable) both succeed against the modified `setup.py`, and `import aidp_chat_client` works in both modes.

**Test Configuration**:
* Python: 3.11 (container) / 3.14 (laptop)
* Docker: Rancher Desktop 29.x on Apple Silicon
* OCI region: sa-saopaulo-1 (Container Instance) calling an AIDP agent in us-ashburn-1

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
