### PR TITLE
Sample/multi mcp chat agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,11 @@ pytest_cache/
 tmp/
 temp/
 .cache/
+
+# =========================
+# Local agent config (may contain secrets)
+# =========================
+ai/agent-flows/code-first/multi-mcp-chat-agent/config.yaml
+ai/agent-flows/code-first/multi-mcp-chat-agent/oac-jwt-key.pem
+ai/agent-flows/code-first/multi-mcp-chat-agent/oac-jwt-key.txt
+ai/agent-flows/code-first/multi-mcp-chat-agent/oac-cert.pem

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Notebooks covering generative AI, NLP, ML model training, and LLM-powered analyt
 | Notebook | Description |
 |---|---|
 | [Agent Flow Schedule Trigger](ai/agent-flows/misc/agent-flow-schedule-trigger/task_notebook.ipynb) | Invoke AIDP agent flows via REST API using OCI request signing, demonstrating programmatic agent orchestration with custom message handling. |
+| [Multi-MCP Chat Agent](ai/agent-flows/code-first/multi-mcp-chat-agent/README.md) | Natural-language chat agent that fans out across Oracle Autonomous Database (Select AI MCP), Oracle Analytics Cloud (Logical SQL MCP), and Oracle Integration Cloud (project-scoped MCP). Each integration can be enabled or disabled independently via config. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Notebooks covering generative AI, NLP, ML model training, and LLM-powered analyt
 | Notebook | Description |
 |---|---|
 | [Agent Flow Schedule Trigger](ai/agent-flows/misc/agent-flow-schedule-trigger/task_notebook.ipynb) | Invoke AIDP agent flows via REST API using OCI request signing, demonstrating programmatic agent orchestration with custom message handling. |
+
+#### Code-First Agent Flows
+
+| Sample | Description |
+|---|---|
 | [Multi-MCP Chat Agent](ai/agent-flows/code-first/multi-mcp-chat-agent/README.md) | Natural-language chat agent that fans out across Oracle Autonomous Database (Select AI MCP), Oracle Analytics Cloud (Logical SQL MCP), and Oracle Integration Cloud (project-scoped MCP). Each integration can be enabled or disabled independently via config. |
 
 ---

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/README.md
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/README.md
@@ -1,0 +1,406 @@
+# Multi-MCP Chat Agent for AIDP
+
+A natural-language chat agent for AIDP (Oracle AI Data Platform) that fans
+out across **three** Oracle data sources via the Model Context Protocol:
+
+- **Oracle Autonomous Database (ADB)** — transactional records via Select AI MCP (NL → SQL)
+- **Oracle Analytics Cloud (OAC)** — subject areas / datasets via Logical SQL
+- **Oracle Integration Cloud (OIC) 3** — integrations exposed as tools through OIC's project-scoped MCP server
+
+Every server is reached over HTTPS MCP. There is no Node.js subprocess and
+no local bridge — token management is fully Python-native. All three
+servers authenticate via OAuth 2.0 grants:
+**ADB → password grant**, **OAC → JWT Bearer (User Assertion)**, **OIC →
+client_credentials**. Each can be re-authenticated on demand from cached
+config, so there's no rotating refresh chain that can break overnight.
+
+Each integration can be **independently enabled or disabled** in
+[./config.yaml](./config.yaml) — you can run the agent with just ADB, just
+OAC, just OIC, or any combination.
+
+---
+
+## Folder layout
+
+```
+multi-mcp-chat-agent/
+├── README.md                ← this file
+├── agent.py                 ← the AgentBasic AIDP entrypoint
+├── config.sample.yaml       ← config template with inline setup notes
+├── enable-mcp-selectai.sql  ← ADB-side SQL template (only if ADB enabled)
+└── mint-and-exchange.py     ← OAC JWT verification helper (only if OAC enabled)
+```
+
+Use [./config.sample.yaml](./config.sample.yaml),
+[./enable-mcp-selectai.sql](./enable-mcp-selectai.sql), and
+[./mint-and-exchange.py](./mint-and-exchange.py) as shareable
+templates — copy and customize before running.
+
+---
+
+## Quick start
+
+1. Copy [./config.sample.yaml](./config.sample.yaml) to
+   [./config.yaml](./config.yaml) and fill in values for any integration
+   you want to enable. Set `enabled: false` on the rest.
+2. (If OAC is enabled) Follow the OAC JWT setup steps below — generate a
+   keypair, register the cert in IDCS, prep `oac-jwt-key.txt`. Verify the
+   chain with [./mint-and-exchange.py](./mint-and-exchange.py) BEFORE
+   deploying the agent.
+3. Upload [./agent.py](./agent.py), [./config.yaml](./config.yaml) (your
+   version of [./config.sample.yaml](./config.sample.yaml) with your
+   parameters), and [./oac-jwt-key.txt](./oac-jwt-key.txt) (if OAC) to
+   your AIDP project. Deploy through the AIDP agent UI (NOT the play
+   button — that bypasses the OCI signer wiring needed for the LLM).
+4. Send a message in the AIDP chat panel. The first message takes a few
+   seconds while MCP sessions warm up; subsequent messages are fast.
+
+---
+
+## Per-integration setup
+
+This guide covers **only** what's needed to expose each Oracle service over
+MCP and connect this agent to it. It assumes you already have an ADB
+instance with data, an OAC instance with datasets/subject areas, and an
+OIC project with integrations — building those is out of scope.
+
+### 1. LLM (always required)
+
+OCI Generative AI is the LLM backend. The agent uses OCI's signer
+principal injected by AIDP — no API key needed.
+
+- Pick a compartment on-listed for OCI Generative AI in your region.
+- Choose any chat-capable model from the catalog. `xai.grok-4-fast-non-reasoning`
+  is a solid default.
+- Fill in `llm.compartment_id`, `llm.region`, `llm.model_id` in
+  [./config.yaml](./config.yaml).
+
+### 2. Enable Select AI MCP on ADB
+
+Two pieces are needed: a **tag on the ADB instance** (OCI Console) to
+expose the MCP endpoint, and **SQL inside the database** to enable
+resource-principal auth, create a Select AI profile, and register at
+least one tool.
+
+**Prerequisites**: ADB 19c v19.29+ or 26ai v23.26+. Older versions don't
+support Select AI MCP.
+
+**a. Enable MCP on the ADB instance (OCI Console — required first)**
+
+Without this tag the data-access MCP endpoint isn't exposed, no matter
+what you do in SQL.
+
+- OCI Console → Autonomous Database → your ADB instance → **Tags** →
+  **Add tag**:
+  - **Tag namespace**: leave free-form
+  - **Tag key**: `adb$feature`
+  - **Tag value**: `{"name":"mcp_server","enable":true}`
+- Save. Within ~1 minute the MCP endpoint at
+  `https://dataaccess.adb.<region>.oraclecloudapps.com/adb/mcp/v1/databases/<adb_ocid>`
+  becomes live.
+
+**b. Create the Select AI profile and MCP tool (in-database SQL)**
+
+Use [./enable-mcp-selectai.sql](./enable-mcp-selectai.sql)
+as a starting point. Open it in SQL Developer Web (connected as `ADMIN`),
+edit the four marked spots if you want to (profile name, schema owner, tool name, smoke
+test question), and run each block sequentially. The template:
+
+1. Drops any old credential (idempotent).
+2. Calls `DBMS_CLOUD_ADMIN.ENABLE_RESOURCE_PRINCIPAL()` so ADB can call
+   OCI Generative AI as itself — creates the `OCI$RESOURCE_PRINCIPAL`
+   credential automatically.
+3. Auto-discovers all tables in the schema and creates a Select AI
+   profile pointing at `provider=oci` with the resource-principal
+   credential.
+4. Registers the profile as an MCP tool via
+   `DBMS_CLOUD_AI_AGENT.CREATE_TOOL`. **The tool is what MCP exposes** —
+   no tool, no MCP traffic.
+5. Smoke-tests with `DBMS_CLOUD_AI.GENERATE(..., action => 'runsql')`.
+
+**c. Wire up [./config.yaml](./config.yaml)**
+
+Note the ADB OCID, region, and user/password the agent will use. Set
+`integrations.adb.enabled` to `true` and fill in the rest.
+
+**Auth model**: OAuth 2.0 Resource Owner Password Credentials grant
+(commonly "password grant") against ADB's data-access endpoint. The
+agent fetches a fresh bearer on every MCP rebuild — no token persistence
+needed.
+
+### 3. OAC MCP server (JWT User Assertion)
+
+OAC exposes MCP at `/api/mcp` on the analytics host. The agent
+authenticates via **OAuth 2.0 JWT User Assertion**: it locally signs a
+short-lived JWT using a private key, exchanges it at IDCS for an OAC
+access_token, and uses that bearer to call `/api/mcp`. There's no
+rotating refresh chain — every access_token is freshly minted, so the
+chain can't break overnight (the failure mode of the older OAC
+`tokens.json` flow).
+
+The trade-off: the JWT must assert a real OAC user as the `sub` claim,
+so the agent operates as a **dedicated service user** (e.g.
+`oac-agent-svc@your-org.com`). All chat users see OAC data filtered as
+that service user — no per-user RLS in this sample.
+
+> **Security note**: Setting Client Type to "Trusted" and registering a
+> cert is essentially the IDCS admin authorizing the cert holder to
+> impersonate any active user in the domain. This is by design (same
+> model as GCP Service Accounts, AWS STS, Kerberos S4U). Treat the
+> private key like a root password: never commit it, rotate annually,
+> and prefer a low-privilege service user over your personal account.
+> Per-user RLS *is* possible by minting per-message JWTs based on the
+> chat user's identity, but that's not implemented in this sample.
+
+#### One-time IDCS setup
+
+**a. Generate keypair + X.509 cert** (on your laptop):
+
+```bash
+openssl genrsa -out oac-jwt-key.pem 2048
+openssl req -x509 -key oac-jwt-key.pem -out oac-cert.pem \
+  -days 365 -subj "/CN=oac-mcp-agent"
+```
+
+**b. IDCS Confidential Application**:
+
+You can **reuse the OIC Confidential App** if you already created one
+for OIC, OR create a separate one for OAC. Either way, on that App:
+
+- **Allowed grant types**: ☑ **JWT Assertion** AND ☑ **Client Credentials**.
+  Both are needed — Client Credentials gates the validation of our
+  `client_assertion` JWT even though we're using the JWT-bearer grant.
+  Without it you get a generic "system error" from IDCS.
+- **Edit OAuth configuration** → set **Client type: Trusted** (not
+  Confidential — Trusted is required to import a signing cert).
+- **Certificate** section → click **Import certificate** → upload
+  `oac-cert.pem`, give it a memorable **Alias** like `oac-mcp` (you'll
+  put this same value in `config.yaml` as `cert_alias`). IDCS wants an
+  X.509 cert here, not just a public key — that's why the
+  `openssl req -x509` step is mandatory.
+- **Token Issuance Policy → Resources**: click **Add scope** and search
+  for your OAC instance. It registers under a name like
+  `ANALYTICSINST_<your-host>-<region>` (search for `analyticsinst` if
+  filtering by `oac` doesn't find it — Visual Builder shows up under
+  `oac` but isn't what you want). Pick the scope ending in
+  `urn:opc:resource:consumer::all`. Copy that full scope URL — you'll
+  put it in `config.yaml`.
+- **Status**: Active.
+
+If reusing the OIC app: no new client_id/secret to generate. Just enable
+the JWT grant type, switch to Trusted client type, import the cert, and
+add the OAC scope.
+
+**c. OAC service user**:
+
+In OAC, identify or create the service user (e.g.
+`oac-agent-svc@your-org.com`). Grant them the OAC permissions you want
+the agent to inherit (typically read access on the relevant subject
+areas / datasets).
+
+#### Verify the chain (recommended before deploying agent.py)
+
+Before touching agent.py / config.yaml in AIDP, confirm the IDCS+OAC
+config is correct using [./mint-and-exchange.py](./mint-and-exchange.py).
+It mints both JWTs, exchanges them at IDCS, and prints a curl one-liner
+to test against `/api/mcp`. If both succeed, you're ready to deploy. If
+they fail, fix IDCS first — don't waste cycles debugging the agent.
+
+You can run it in **two ways** — pick whichever is easier for you:
+
+**Option 1 — From your laptop**:
+
+Requires Python 3.11+ with `requests` and `cryptography` installed
+(`pip install requests cryptography`). Edit the CONFIG block at the top
+of the script with your values, then:
+
+```bash
+cd /path/to/multi-mcp-chat-agent
+python3 mint-and-exchange.py
+```
+
+**Option 2 — From inside AIDP** (if you don't want to install Python
+locally, or want to test from the same network the agent will run in):
+
+The script uses only `requests` and `cryptography`, both of which are
+already in AIDP's runtime — same dependencies the agent itself relies
+on. Upload `mint-and-exchange.py` to your AIDP project alongside the
+key file, then use AIDP's "play / run" button on the script to execute
+it. The output (token preview + curl command) will appear in AIDP's
+script-output panel.
+
+Either way: if the script prints `✓ access_token` and the curl call
+returns 200 with a `tools` list, you're set. If it errors, check the
+IDCS error code and the troubleshooting table at the bottom of this
+README for what to fix.
+
+#### Wire up [./config.yaml](./config.yaml)
+
+- **Rename `oac-jwt-key.pem` → `oac-jwt-key.txt`**. Reason: AIDP's file
+  picker (the dropdown when uploading files into a project) only accepts
+  certain extensions — Python, JSON, TXT, CSV, PSV, SH, YAML — and
+  `.pem` isn't on that list. The file content is identical PEM bytes;
+  the rename is purely to make AIDP accept the upload. The agent reads
+  it as raw bytes and feeds them to `cryptography.load_pem_private_key`,
+  so the actual format on disk is still PEM.
+
+  ```bash
+  cp oac-jwt-key.pem oac-jwt-key.txt
+  ```
+
+- Upload `oac-jwt-key.txt` to the same AIDP project folder as
+  [./agent.py](./agent.py).
+- Set `integrations.oac.enabled` to `true` and fill in:
+  - `url` — the OAC analytics base URL (NOT including `/api/mcp`)
+  - `idcs_host` — your OCI Identity Domain host
+  - `client_id` — the Confidential App client_id
+  - `service_user_email` — the OAC service user's email
+  - `scope` — the full scope URL you copied from Token Issuance Policy
+    → Resources. Format:
+    `https://<hash>.analytics.ocp.oraclecloud.comurn:opc:resource:consumer::all`
+    (note: hash hostname, not the user-facing `lucastestoac-*` URL; no
+    `://` separator before `urn:`).
+  - `cert_alias` — the alias you set when importing the cert in IDCS
+    (e.g. `oac-mcp`). The agent puts this in the JWT `kid` header so
+    IDCS can find the right cert to verify the signature against.
+  - `private_key_filename` — defaults to `oac-jwt-key.txt`
+
+#### How the agent uses this at runtime
+
+- **At deploy time** (`setup()`): stages `oac-jwt-key.txt` →
+  `$HOME/oac-mcp/jwt-signing.pem`, loads the private key into memory,
+  mints the first access_token by signing two JWTs and exchanging them
+  at IDCS.
+- **No background refresh loop, no proactive freshness check.** All
+  three integrations (ADB password grant, OAC JWT assertion, OIC
+  client_credentials) can be re-authenticated on demand from cached
+  config + private key — there's no rotating refresh chain that needs
+  scheduled tending.
+- **On error mid-message**: if a tool call fails with an auth or
+  network error (401/403, ClosedResourceError, etc.), the reactive
+  retry path mints a fresh JWT, rebuilds MCP, heals any orphan
+  tool_calls in conversation state, and tries the same message once
+  more. The user sees ~1-2s of extra latency the first time they chat
+  after a long idle, but never a failed message.
+- **The only operational break point** is **key rotation** — yearly or
+  whatever cadence you choose. To rotate: regenerate the keypair,
+  register the new cert in IDCS (delete the old alias or upload
+  alongside), re-upload `oac-jwt-key.txt` to AIDP, redeploy.
+
+### 4. OIC MCP server
+
+OIC's MCP server is per-project. Enabling it is three orthogonal pieces
+that ALL must be in place — missing any one results in `403 Forbidden`,
+empty tool lists, or `invalid_scope`.
+
+**a. Enable MCP on the project**
+
+- In OIC Designer, open the project.
+- Click the **pencil / Edit** icon at the top right of the project page.
+- ☑ **Enable MCP server** → **Save**.
+- Re-open the edit panel — the **MCP server URL** field is now visible.
+  Canonical pattern (use this if the displayed URL looks wrong):
+  `https://<oic-host>/mcp-server/v1/projects/<projectId>/mcp`.
+
+**b. Register tools via the AI Agents tab**
+
+OIC doesn't auto-publish all integrations to MCP. You explicitly pick
+which ones to expose and write a description the LLM will see.
+
+- In the project sidebar → **AI Agents** → **Tools** → **Add**.
+- The **Integration** dropdown only shows integrations that are
+  *eligible*: **REST-triggered, activated, and shared with other projects**.
+  A scheduled integration won't appear; an integration without
+  "Share with other projects" enabled won't either.
+- Pick one, give it a name, and write a clear **description** — the
+  description is what the LLM uses to decide when to call the tool.
+- Save. Repeat for each integration you want exposed.
+
+**c. Confidential Application + ServiceInvoker role**
+
+The MCP endpoint authenticates via OAuth 2.0 client_credentials. There
+is **no** OCI Resource Principal, no API-key signing, no Basic Auth path
+for OIC MCP — Oracle's docs are explicit on this.
+
+- In your OCI Identity Domain (IDCS), create or reuse a **Confidential
+  Application**. Allowed grant types must include **Client Credentials**.
+- Under **OAuth configuration → Token issuance policy → Resources**, add
+  the OIC instance application. Two scopes appear — add **both**:
+  - `urn:opc:resource:consumer::all` on the instance host
+  - `/ic/api/` on the same host
+- Both scopes use the **IDCS-registered hash hostname** (something like
+  `1CE41DD5...integration.region.ocp.oraclecloud.com`) — NOT the
+  user-facing `design.*` console hostname. Copy them verbatim from the
+  Resources table.
+- **Activate** the application (Actions → Activate at the top of the
+  app detail page).
+- **Map the App to `ServiceInvoker`** on the OIC instance — this is the
+  most-missed step:
+  - OCI Console → Identity → Domains → your domain → **Oracle Cloud
+    Services** → your OIC instance → **Application Roles** →
+    **ServiceInvoker** → **Assigned applications** → assign the
+    Confidential App.
+  - `ServiceAdministrator` alone is **not enough** — MCP specifically
+    requires `ServiceInvoker`. A token without it returns `403` from the
+    MCP endpoint even though the OAuth round-trip succeeds.
+
+**d. config.yaml**
+
+Set `integrations.oic.enabled` to `true` and fill in `mcp_url`,
+`idcs_host`, `client_id`, `client_secret`, and `scope` (the two scope
+URLs space-separated).
+
+**Auth model**: OAuth 2.0 client_credentials. Token TTL ~1 hour. No
+scheduled refresh — the agent re-fetches a fresh bearer on demand,
+triggered by the reactive-retry path when a tool call fails with 401.
+
+**Sanity check** — verify the OAuth + MCP chain works locally before
+deploying:
+
+```bash
+TOKEN=$(curl -s -u "<client_id>:<client_secret>" \
+  -d "grant_type=client_credentials" \
+  --data-urlencode "scope=<your space-separated scopes>" \
+  https://<idcs_host>/oauth2/v1/token | jq -r .access_token)
+
+curl -i -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  <oic_mcp_url>
+```
+
+A 200 with a `tools` array confirms the chain is sound. A 403 typically
+means the `ServiceInvoker` role mapping is missing.
+
+---
+
+## Concurrency
+
+The agent serves all chat users from one Python process. Concurrent calls
+to ADB MCP, OAC MCP, OIC MCP, and OCI Generative AI all run in parallel.
+Conversation state is per-user via AIDP's `thread_id`.
+
+A single `asyncio.Lock` serializes MCP rebuilds (first load and
+reactive auth-error retry) to prevent races. Tool-call execution is
+unaffected.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `MCP setup error: ... 401 Unauthorized` on ADB | wrong ADB user/password or OCID | check [./config.yaml](./config.yaml) values; try logging in via SQL Developer Web |
+| `🔑 OAC JWT authentication failed` in chat → IDCS `invalid_grant` | service user disabled, missing, or wrong email | check `integrations.oac.service_user_email` against an Active OAC user |
+| `🔑 OAC JWT authentication failed` in chat → IDCS `invalid_client` | cert not registered, or wrong `client_id` | re-upload `oac-cert.pem` as a Trusted Client cert on the Confidential App; verify `integrations.oac.client_id` |
+| `🔑 OAC JWT authentication failed` in chat → IDCS `invalid_request` / signature | wrong private key, malformed JWT, or clock skew > 5 min | confirm `oac-jwt-key.txt` matches the cert in IDCS; verify the AIDP container clock is roughly correct |
+| OAC works but tools return empty | service user lacks data access | grant the service user permissions on the OAC subject areas / datasets you query |
+| `403 Forbidden` on OIC MCP | Confidential App not mapped to `ServiceInvoker` on the OIC instance | OCI Console → Identity → Domains → Oracle Cloud Services → your OIC → Application Roles → ServiceInvoker → assign the App |
+| `invalid_scope` from IDCS | scope value uses the wrong hostname or is missing from Token issuance policy | copy scope verbatim from the App's Token issuance policy → Resources |
+| `OAuth Client app is inactive` | Confidential App is in Inactive state | App detail page → Actions → Activate |
+| OIC MCP returns no tools | project's "Enable MCP server" flag is off, or no tool registered under AI Agents → Tools | tick the flag, register at least one integration as a tool |
+| First message after long idle is slow, subsequent ones fast | reactive retry caught a 401, minted a fresh JWT, and rebuilt MCP | expected; this is the recovery path. Look for "Recoverable error mid-invoke" log line |
+
+---

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/README.md
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/README.md
@@ -271,17 +271,31 @@ README for what to fix.
   `$HOME/oac-mcp/jwt-signing.pem`, loads the private key into memory,
   mints the first access_token by signing two JWTs and exchanging them
   at IDCS.
-- **No background refresh loop, no proactive freshness check.** All
-  three integrations (ADB password grant, OAC JWT assertion, OIC
-  client_credentials) can be re-authenticated on demand from cached
-  config + private key — there's no rotating refresh chain that needs
-  scheduled tending.
-- **On error mid-message**: if a tool call fails with an auth or
-  network error (401/403, ClosedResourceError, etc.), the reactive
-  retry path mints a fresh JWT, rebuilds MCP, heals any orphan
-  tool_calls in conversation state, and tries the same message once
-  more. The user sees ~1-2s of extra latency the first time they chat
-  after a long idle, but never a failed message.
+- **No background refresh loop.** All three integrations (ADB password
+  grant, OAC JWT assertion, OIC client_credentials) can be
+  re-authenticated on demand from cached config + private key — there's
+  no rotating refresh chain that needs scheduled tending.
+- **Proactive OAC freshness check at the start of every `invoke()`.**
+  OAC's IDCS-issued access_tokens have a short 5-minute TTL (much
+  shorter than ADB's or OIC's), and AIDP suspends the agent process
+  during idle — so a session that was warm hours ago will have a
+  long-expired bearer baked into the MCP client headers. Before the
+  LLM sees OAC, `_ensure_fresh_oac_token()` decodes the cached
+  bearer's `exp` claim; if there are ≤60s left it mints a fresh JWT,
+  exchanges it at IDCS, and rebuilds MCP. The 60s threshold is
+  comfortably above any plausible tool-call duration and absorbs
+  clock skew, so a single user turn's chained tool calls (discover →
+  describe → execute) all see the same fresh token. Cheap when the
+  token is fresh (one JWT decode); ~300ms when refresh is needed.
+  ADB and OIC are not pre-checked — their tokens are longer-lived
+  and the reactive path below handles them.
+- **On error mid-message**: if a tool call still fails with an auth
+  or network error (401/403, ClosedResourceError, etc.) — e.g. an
+  unusually long tool execution that outlived the freshly minted
+  bearer, or an ADB/OIC token that expired — the reactive retry path
+  mints a fresh JWT, rebuilds MCP, heals any orphan tool_calls in
+  conversation state, and tries the same message once more. The user
+  may see ~1-2s of extra latency but never a failed message.
 - **The only operational break point** is **key rotation** — yearly or
   whatever cadence you choose. To rotate: regenerate the keypair,
   register the new cert in IDCS (delete the old alias or upload

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/agent.py
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/agent.py
@@ -1,0 +1,1054 @@
+"""
+Multi-MCP Chat Agent for AIDP — Oracle ADB SelectAI + OAC + OIC.
+
+This is the entry point AIDP looks for when it deploys this folder as
+an agent. AIDP loads this file, finds the AgentBasic class, and calls
+its setup() once and invoke() per chat message.
+
+Reads configuration from ./config.yaml (the sibling file). Each
+integration (adb / oac / oic) can be turned on or off independently.
+See README.md for the end-to-end setup walkthrough.
+
+Quick architecture:
+  • Agent state lives in memory only (one Python process serves all
+    chat users from the same AgentBasic instance).
+  • MCP tool execution happens via short-lived HTTPS requests — there
+    are no persistent network connections to keep alive.
+  • Auth is on-demand only. All three integrations authenticate via
+    OAuth 2.0 grants — none use a rotating refresh chain:
+        - ADB:  password grant (RFC 6749 §4.3)
+        - OAC:  JWT Bearer / User Assertion (RFC 7523), local-signed
+                from a long-lived private key
+        - OIC:  client_credentials (RFC 6749 §4.4)
+    So we don't run any background refresh loop. Tokens get rebuilt
+    only when a tool call fails with 401/connection error — the
+    reactive retry in invoke() catches that, mints fresh bearers,
+    and retries.
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import os
+import time
+import traceback
+import uuid
+from pathlib import Path
+
+import requests
+
+from langchain_core.messages import HumanMessage, RemoveMessage
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+from aidputils.agents.toolkit.agent_helper import init_oci_llm, pre_invoke_setup
+from aidputils.agents.toolkit.configs import OCIAIConf
+
+logger = logging.getLogger(__name__)
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   Config loading                                             ║
+# ║                                                              ║
+# ║   We read config.yaml at module import time, BUT wrap        ║
+# ║   everything in try/except so a broken config doesn't kill   ║
+# ║   the import — if it did, AIDP would just say "Agent not     ║
+# ║   loaded or available" with no detail. By capturing the      ║
+# ║   error here and surfacing it in chat from setup() later,    ║
+# ║   the user sees a real diagnostic message.                   ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+_CFG_INIT_ERROR: str | None = None
+_CFG_PATHS_TRIED: list[str] = []
+CFG: dict = {}
+
+
+def _find_config_yaml() -> Path | None:
+    """Look for config.yaml in the most likely places. AIDP doesn't always
+    deploy non-.py files next to the agent script the way you'd expect, so
+    we check a few candidate paths and fall back to a bounded recursive
+    search if needed."""
+    # Direct paths to try first — fast (no scanning).
+    direct = [
+        Path(__file__).resolve().parent / "config.yaml",  # next to agent.py
+        Path.cwd() / "config.yaml",                       # current working dir
+        Path.cwd().parent / "config.yaml",                # one level up
+        Path.home() / "config.yaml",                      # $HOME
+    ]
+    for c in direct:
+        _CFG_PATHS_TRIED.append(str(c))
+        if c.exists():
+            return c
+
+    # Fallback: recursive search inside the deployment subtree only.
+    # Important: NEVER recurse from Path.home() — that could scan a huge
+    # tree on shared hosts and stall the agent for minutes.
+    for base in (Path.cwd(), Path.cwd().parent):
+        if not base.exists():
+            continue
+        try:
+            for p in base.rglob("config.yaml"):
+                _CFG_PATHS_TRIED.append(f"(rglob match) {p}")
+                return p
+        except Exception:
+            pass  # filesystem errors during scan — try the next base
+    return None
+
+
+try:
+    import yaml  # PyYAML — confirmed pre-installed in AIDP runtime (6.0.2)
+    found = _find_config_yaml()
+    if found is None:
+        raise FileNotFoundError(
+            "config.yaml not found in any expected location. Searched:\n"
+            + "\n".join(f"  • {p}" for p in _CFG_PATHS_TRIED)
+            + "\n\nAIDP may not bundle non-.py files automatically. "
+            + "Try uploading config.yaml again from the AIDP project file "
+            + "explorer (same place where you uploaded agent.py)."
+        )
+    # `yaml.safe_load` returns None for empty files — we coerce to {} so
+    # downstream code can use .get() safely without None checks everywhere.
+    CFG = yaml.safe_load(found.read_text()) or {}
+    logger.info("Loaded config.yaml from %s", found)
+except Exception:
+    # Capture the full traceback so we can show it in chat later. We
+    # deliberately catch BaseException-style broadly (Exception covers
+    # everything we care about here — file errors, YAML parse errors,
+    # ImportError if PyYAML somehow disappears).
+    import traceback as _tb
+    _CFG_INIT_ERROR = _tb.format_exc()
+
+LLM_COMPARTMENT_ID = CFG.get("llm", {}).get("compartment_id", "")
+LLM_REGION         = CFG.get("llm", {}).get("region", "us-ashburn-1")
+LLM_MODEL_ID       = CFG.get("llm", {}).get("model_id", "")
+
+ADB_CFG     = CFG.get("integrations", {}).get("adb", {}) or {}
+ADB_ENABLED = bool(ADB_CFG.get("enabled", False))
+
+OAC_CFG     = CFG.get("integrations", {}).get("oac", {}) or {}
+OAC_ENABLED = bool(OAC_CFG.get("enabled", False))
+
+OIC_CFG     = CFG.get("integrations", {}).get("oic", {}) or {}
+OIC_ENABLED = bool(OIC_CFG.get("enabled", False))
+
+# OAC paths (only used if OAC enabled)
+OAC_HOME             = Path.home() / "oac-mcp"
+OAC_PRIVATE_KEY      = OAC_HOME / "jwt-signing.pem"
+OAC_PRIVATE_KEY_NAME = OAC_CFG.get("private_key_filename", "oac-jwt-key.txt")
+OAC_TOKEN_URL        = (
+    f"https://{OAC_CFG.get('idcs_host', '')}/oauth2/v1/token" if OAC_ENABLED else ""
+)
+OAC_MCP_URL          = f"{OAC_CFG.get('url', '')}/api/mcp"
+
+# OIC OAuth (only used if OIC enabled)
+OIC_TOKEN_URL = (
+    f"https://{OIC_CFG.get('idcs_host', '')}/oauth2/v1/token" if OIC_ENABLED else ""
+)
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   Agent prompt — adapts to enabled integrations              ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def _build_system_prompt() -> str:
+    parts = [
+        "You are a helpful data assistant with access to tools loaded "
+        "from one or more MCP servers."
+    ]
+    if ADB_ENABLED:
+        parts.append(
+            "  - ADB SelectAI tools: query a transactional Oracle Autonomous "
+            "Database in natural language (transactions, accounts, customers)."
+        )
+    if OAC_ENABLED:
+        parts.append(
+            "  - Oracle Analytics Cloud (OAC) tools: query OAC subject areas / "
+            "datasets with governance-aware Logical SQL. Use these for "
+            "analytical / reporting questions about pre-modeled data."
+        )
+    if OIC_ENABLED:
+        parts.append(
+            "  - Oracle Integration Cloud (OIC) tools: invoke OIC integrations "
+            "exposed as tools by the OIC project's MCP server. Use these "
+            "for questions about integrations, audit reports, and "
+            "orchestration exposed by the OIC instance."
+        )
+    parts.append("")
+    parts.append("Rules:")
+    parts.append(
+        "  - Pick the right tool for each question. If unsure where data "
+        "lives, use a discover-style tool first."
+    )
+    if ADB_ENABLED:
+        parts.append(
+            "  - For SelectAI: use action='runsql' for data, 'showsql' to "
+            "see SQL, 'explainsql' to explain."
+        )
+    if OAC_ENABLED:
+        parts.append(
+            "  - For OAC Logical SQL: discover_data and describe_data "
+            "before execute_logical_sql so you know table/column names."
+        )
+    parts.append("  - Pass the user's actual question; never substitute or invent.")
+    parts.append("  - For follow-ups, rewrite using prior turn context, then call the tool.")
+    parts.append("  - After a tool returns, summarize in plain English. Don't dump raw JSON unless asked.")
+    parts.append("  - Never invent numbers — if a tool errored, say so.")
+    return "\n".join(parts)
+
+
+AGENT_SYSTEM_PROMPT = _build_system_prompt()
+
+llm_conf = OCIAIConf(
+    model_provider="generic",
+    compartment_id=LLM_COMPARTMENT_ID,
+    model_args={},
+    endpoint=f"https://inference.generativeai.{LLM_REGION}.oci.oraclecloud.com",
+    model_id=LLM_MODEL_ID,
+    guardrails_config={"name": "Default", "description": "", "policies": []},
+)
+
+checkpointer = globals().get("checkpointer", None)
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   ADB — password-grant bearer                                ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def _adb_bearer_token() -> str:
+    auth_url = (
+        f"https://dataaccess.adb.{ADB_CFG['region']}.oraclecloudapps.com"
+        f"/adb/auth/v1/databases/{ADB_CFG['ocid']}/token"
+    )
+    r = requests.post(
+        auth_url,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "grant_type": "password",
+            "username": ADB_CFG["user"],
+            "password": ADB_CFG["password"],
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+def _adb_mcp_url() -> str:
+    return (
+        f"https://dataaccess.adb.{ADB_CFG['region']}.oraclecloudapps.com"
+        f"/adb/mcp/v1/databases/{ADB_CFG['ocid']}"
+    )
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   OIC — client_credentials against IDCS                      ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def _oic_bearer_token() -> str:
+    r = requests.post(
+        OIC_TOKEN_URL,
+        auth=(OIC_CFG["client_id"], OIC_CFG["client_secret"]),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={"grant_type": "client_credentials", "scope": OIC_CFG["scope"]},
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   OAC — JWT User Assertion (no rotating tokens, no expiry)   ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def _stage_oac_private_key() -> None:
+    """Find the uploaded PEM private key (default name: oac-jwt-key.txt
+    — AIDP's file picker accepts .txt) and copy it to OAC_PRIVATE_KEY.
+    Idempotent: only writes if the upload differs from the staged copy."""
+    OAC_HOME.mkdir(parents=True, exist_ok=True)
+    src = None
+    for base in (Path.cwd(), Path.cwd().parent):
+        if not base.exists():
+            continue
+        for p in base.rglob(OAC_PRIVATE_KEY_NAME):
+            if p == OAC_PRIVATE_KEY:
+                continue
+            src = p
+            break
+        if src:
+            break
+
+    if src is None:
+        if not OAC_PRIVATE_KEY.exists():
+            raise FileNotFoundError(
+                f"{OAC_PRIVATE_KEY_NAME} not found in AIDP project. "
+                "Generate the keypair, register the cert in IDCS, then "
+                f"upload the PEM private key as {OAC_PRIVATE_KEY_NAME} "
+                "alongside agent.py. See README.md for full steps."
+            )
+        print(f"[stage] OAC private key at {OAC_PRIVATE_KEY} (no new upload)")
+        return
+
+    src_bytes    = src.read_bytes()
+    staged_bytes = OAC_PRIVATE_KEY.read_bytes() if OAC_PRIVATE_KEY.exists() else b""
+    if src_bytes == staged_bytes:
+        print(f"[stage] Uploaded {OAC_PRIVATE_KEY_NAME} identical to staged — keeping")
+        return
+
+    print(f"[stage] New {OAC_PRIVATE_KEY_NAME} at {src} → {OAC_PRIVATE_KEY}")
+    OAC_PRIVATE_KEY.write_bytes(src_bytes)
+
+
+def _load_oac_private_key():
+    """Load the PEM private key from disk. Returns a cryptography RSA
+    private key object usable for signing JWTs."""
+    from cryptography.hazmat.primitives.serialization import load_pem_private_key
+    return load_pem_private_key(OAC_PRIVATE_KEY.read_bytes(), password=None)
+
+
+def _mint_jwt(claims: dict, private_key, kid: str | None = None) -> str:
+    """Hand-build an RS256-signed JWT.
+
+    We don't use the PyJWT library because it's not guaranteed to be in
+    AIDP's runtime, and we already established that runtime pip installs
+    don't work reliably. The `cryptography` library IS guaranteed to be
+    there (it's pulled in by the oci SDK and requests/urllib3), so we use
+    it directly. Total: ~15 lines of base64 + JSON encoding instead of an
+    extra dependency we'd have to babysit.
+
+    JWT structure: three base64url-encoded parts joined by dots:
+      <header>.<claims>.<signature>
+
+    `kid` is the certificate alias you set in IDCS when uploading the
+    public cert. IDCS uses it to look up which trusted cert to verify the
+    signature with. Required for our use case — without it, IDCS rejects
+    the assertion with a generic "system error" message."""
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import padding
+
+    def b64url(d: dict) -> bytes:
+        # JWT uses base64url encoding without padding ('=' chars stripped).
+        # `separators=(",", ":")` produces compact JSON (no extra spaces).
+        return base64.urlsafe_b64encode(
+            json.dumps(d, separators=(",", ":")).encode()
+        ).rstrip(b"=")
+
+    header: dict = {"alg": "RS256", "typ": "JWT"}
+    if kid:
+        header["kid"] = kid
+
+    # The signature is computed over "<header>.<claims>".
+    body = b64url(header) + b"." + b64url(claims)
+    signature = private_key.sign(body, padding.PKCS1v15(), hashes.SHA256())
+    sig_b64 = base64.urlsafe_b64encode(signature).rstrip(b"=")
+
+    return (body + b"." + sig_b64).decode()
+
+
+def _fetch_oac_access_token(private_key) -> str:
+    """Mint a fresh OAC access_token using the JWT User Assertion flow.
+
+    How this flow works:
+      1. We sign TWO short-lived JWTs locally with our private key:
+         - The **client assertion** proves *we are this client*.
+           sub = client_id (the Confidential App's ID).
+         - The **user assertion** says *we're acting as this user*.
+           sub = service_user_email.
+      2. We POST both JWTs to IDCS's /oauth2/v1/token endpoint along
+         with the JWT-bearer grant type. IDCS validates the signatures
+         against the X.509 cert we registered (matched via the JWT's
+         `kid` header), and if both check out, returns an access_token
+         scoped to OAC and authenticated AS the asserted user.
+      3. We use that access_token to call OAC's MCP endpoint.
+
+    Important: we deliberately DO NOT use the refresh_token IDCS may
+    return alongside the access_token. The whole reason we picked this
+    flow is to escape the rotating-refresh chain that breaks overnight.
+    When the access_token expires, we just mint a brand new JWT and
+    exchange it again. Cheap (local crypto + one HTTPS call), reliable.
+
+    Counter-intuitive details that took us a while to discover:
+      • `aud` MUST be the LITERAL string "https://identity.oraclecloud.com/"
+        with trailing slash. NOT your tenant's token URL. IDCS's generic
+        Oracle audience for JWT bearer assertions.
+      • `kid` in the JWT header MUST match the cert alias you set when
+        you imported the cert in IDCS. Without it, IDCS can't figure
+        out which trusted cert to verify the signature against.
+      • Both JWTs share the same `iss` (always the client_id) and only
+        differ in `sub`. Don't try to be clever with the issuer claim."""
+    cert_alias = OAC_CFG.get("cert_alias")
+    now = int(time.time())
+
+    # Claims shared by both JWTs. We override `sub` per-assertion below.
+    # exp = 5 min from now — IDCS rejects assertions issued more than
+    # 5 min in the future or already expired, so keep this short.
+    base_claims = {
+        "iss": OAC_CFG["client_id"],
+        "aud": "https://identity.oraclecloud.com/",
+        "iat": now,
+        "exp": now + 300,
+        "jti": str(uuid.uuid4()),  # unique nonce — prevents replay attacks
+    }
+    client_jwt = _mint_jwt(
+        {**base_claims, "sub": OAC_CFG["client_id"]},
+        private_key,
+        kid=cert_alias,
+    )
+    user_jwt = _mint_jwt(
+        {**base_claims, "sub": OAC_CFG["service_user_email"]},
+        private_key,
+        kid=cert_alias,
+    )
+
+    # POST to the IDCS token endpoint with both assertions.
+    r = requests.post(
+        OAC_TOKEN_URL,
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": user_jwt,
+            "client_assertion_type":
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion": client_jwt,
+            "scope": OAC_CFG.get("scope", "urn:opc:resource:consumer::all"),
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    return r.json()["access_token"]
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   MCP server registry — only enabled servers are included    ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+def _build_mcp_config(oac_access_token: str | None) -> dict:
+    cfg: dict = {}
+    if ADB_ENABLED:
+        cfg["adb_selectai"] = {
+            "transport": "streamable_http",
+            "url": _adb_mcp_url(),
+            "headers": {"Authorization": f"Bearer {_adb_bearer_token()}"},
+        }
+    if OAC_ENABLED:
+        cfg["oac_analytics"] = {
+            "transport": "streamable_http",
+            "url": OAC_MCP_URL,
+            "headers": {"Authorization": f"Bearer {oac_access_token}"},
+        }
+    if OIC_ENABLED:
+        cfg["oic_integrations"] = {
+            "transport": "streamable_http",
+            "url": OIC_CFG["mcp_url"],
+            "headers": {
+                "Authorization": f"Bearer {_oic_bearer_token()}",
+                "Accept": "application/json, text/event-stream",
+            },
+        }
+    return cfg
+
+
+def _is_auth_error(e: Exception) -> bool:
+    """True when the exception text looks like an authentication or
+    authorization failure (401/403/etc.). Used as a hint that retrying
+    after refreshing tokens might succeed."""
+    msg = str(e).lower()
+    return any(s in msg for s in ("401", "403", "unauthorized", "forbidden", "expired"))
+
+
+def _is_recoverable_error(e: BaseException) -> bool:
+    """Decide whether a failed invoke is worth retrying after rebuilding
+    the MCP stack. We retry on:
+      • Auth errors (401/403) — token may have expired, fresh one might work
+      • Connection-level errors — TCP socket dropped, fresh connection helps
+
+    Why we recurse into ExceptionGroup: the MCP SDK runs tool calls inside
+    asyncio TaskGroups, and a TaskGroup wraps any sub-task exception in an
+    ExceptionGroup. So if a tool call hits a 401, the exception we receive
+    is "ExceptionGroup containing HTTPStatusError(401)" rather than the
+    HTTPStatusError directly. Recursing finds the real cause."""
+    # ExceptionGroup carries its actual children in the `.exceptions`
+    # attribute. If we have one, ask whether ANY sub-exception is recoverable.
+    sub_exceptions = getattr(e, "exceptions", None)
+    if sub_exceptions:
+        return any(_is_recoverable_error(sub) for sub in sub_exceptions)
+
+    # Auth errors: hint to refresh tokens.
+    if isinstance(e, Exception) and _is_auth_error(e):
+        return True
+
+    # Connection-level errors by class name. These names come from various
+    # libraries (anyio, httpx) — match by name so we don't have to import
+    # all of them just to do isinstance checks.
+    cls_name = type(e).__name__
+    if cls_name in ("ClosedResourceError", "BrokenResourceError",
+                    "ConnectionError", "RemoteProtocolError",
+                    "HTTPStatusError"):
+        return True
+
+    # Last-resort string match — sometimes the class name is something
+    # generic but the message tells us it was really a connection issue.
+    msg = str(e).lower()
+    return any(s in msg for s in (
+        "closedresourceerror", "brokenresourceerror",
+        "connection closed", "connection reset", "remote disconnected",
+        "401 unauthorized", "403 forbidden",
+    ))
+
+
+# ╔══════════════════════════════════════════════════════════════╗
+# ║   AgentBasic — what AIDP discovers                           ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+class AgentBasic:
+    def __init__(self) -> None:
+        # The LangGraph react-agent that actually drives chat turns.
+        # Built once in setup() with no tools (so the agent can respond
+        # to messages even before MCP is reachable), then rebuilt with
+        # the loaded MCP tools in _load_all_mcp_tools().
+        self.llm = None
+        self.graph = None
+
+        # Set to True after MCP tools have been loaded at least once.
+        # Used to gate the lazy first-load path in invoke().
+        self._tools_loaded = False
+
+        # If something goes wrong during setup() — config errors, OAC JWT
+        # setup failures, etc. — we capture the message here and return
+        # it to the user as a chat reply on every invoke. Better than
+        # the generic "Agent not loaded" AIDP error.
+        self._self_stage_error: str | None = None
+
+        # Cached OAC bearer (minted via JWT User Assertion). Refreshed
+        # on demand via _refresh_oac_token_and_rebuild().
+        self._oac_access_token: str | None = None
+
+        # The RSA private key used to sign OAC JWTs. Loaded once at
+        # setup() and kept in memory for the agent's lifetime. The
+        # corresponding public cert lives in IDCS as a Trusted Client
+        # cert on the Confidential Application.
+        self._oac_private_key = None
+
+        # asyncio.Lock created lazily on first invoke. Serializes MCP
+        # rebuilds so two concurrent invokes don't both try to refresh
+        # at the same time.
+        self._load_lock = None
+
+    # ── Setup (sync) ────────────────────────────────────────────
+    def setup(self) -> None:
+        logger.info(
+            "Initializing Multi-MCP Chat Agent — enabled: ADB=%s, OAC=%s, OIC=%s",
+            ADB_ENABLED, OAC_ENABLED, OIC_ENABLED,
+        )
+
+        # If the config-load step at module import time failed, surface
+        # the error now via a chat-friendly message. The user sees this
+        # the first time they send a message after a broken deploy.
+        if _CFG_INIT_ERROR:
+            self._self_stage_error = (
+                "config.yaml could not be loaded.\n\n"
+                f"Error:\n{_CFG_INIT_ERROR}\n\n"
+                "Make sure config.yaml is uploaded next to agent.py in the "
+                "AIDP project, and that PyYAML is available in the runtime."
+            )
+            return
+
+        if not (ADB_ENABLED or OAC_ENABLED or OIC_ENABLED):
+            self._self_stage_error = (
+                "No integration enabled in config.yaml. Set 'enabled: true' "
+                "under [integrations.adb], [integrations.oac], or "
+                "[integrations.oic]."
+            )
+            return
+
+        if OAC_ENABLED:
+            try:
+                _stage_oac_private_key()
+                self._oac_private_key = _load_oac_private_key()
+                # Mint the first access_token at setup so the first invoke
+                # doesn't pay the JWT-mint round-trip on top of MCP load.
+                self._oac_access_token = _fetch_oac_access_token(self._oac_private_key)
+            except Exception as e:
+                self._self_stage_error = (
+                    f"{type(e).__name__}: {e}\n\n"
+                    f"Stack trace (last 800 chars):\n{traceback.format_exc()[-800:]}"
+                )
+                logger.error("OAC JWT setup failed: %s", e, exc_info=True)
+
+        self.llm = init_oci_llm(llm_conf)
+        self.graph = create_react_agent(
+            self.llm, [], prompt=AGENT_SYSTEM_PROMPT, checkpointer=checkpointer,
+        )
+        logger.info("Stub graph ready; will load MCP tools on first invoke")
+
+    # ── MCP loading (ephemeral sessions per tool call) ─────────
+    async def _load_all_mcp_tools(self) -> None:
+        """Build a fresh MultiServerMCPClient using the current cached
+        bearer tokens, then ask it for the catalog of available tools.
+
+        Important detail about how MultiServerMCPClient works in this
+        sample: get_tools() uses **ephemeral sessions** — each tool
+        invocation opens a new HTTPS request, runs, and closes. We never
+        hold a persistent TCP connection that could be killed by a load
+        balancer's idle timeout. Trade-off: ~200ms of TLS overhead per
+        tool call. Worth it for not having to keep connections warm.
+
+        Tokens are baked into request headers at client-build time, so
+        when a token expires we just rebuild — driven on-demand by the
+        reactive retry path in invoke() when a tool call fails with an
+        auth or connection error. There's no scheduled refresh: every
+        Oracle service we hit (ADB password grant, OAC JWT assertion,
+        OIC client_credentials) can be re-authenticated independently
+        from cached config + private key, with no rotating refresh chain
+        to keep alive."""
+        cfg = _build_mcp_config(self._oac_access_token)
+        client = MultiServerMCPClient(cfg)
+        tools = await client.get_tools()
+
+        logger.info(
+            "Loaded %d tool(s) from %d MCP server(s) [ephemeral sessions]: %s",
+            len(tools), len(cfg), [t.name for t in tools],
+        )
+        # Re-create the LangGraph react agent with the freshly loaded
+        # tools. The system prompt and checkpointer carry over so chat
+        # state isn't lost when we rebuild.
+        self.graph = create_react_agent(
+            self.llm, tools, prompt=AGENT_SYSTEM_PROMPT, checkpointer=checkpointer,
+        )
+        self._tools_loaded = True
+
+    # ── OAC token refresh (mint a fresh JWT-derived bearer) ─────
+    async def _refresh_oac_token_and_rebuild(self) -> None:
+        """Mint a new OAC access_token via the JWT User Assertion flow,
+        then rebuild MCP so the fresh bearer is in the headers. No refresh
+        chain — just sign a new JWT and exchange. Cheap and idempotent."""
+        self._oac_access_token = await asyncio.to_thread(
+            _fetch_oac_access_token, self._oac_private_key
+        )
+        logger.info("OAC access_token minted via JWT assertion")
+        await self._load_all_mcp_tools()
+
+    # ── Conversation state healing ──────────────────────────────
+    async def _heal_orphan_tool_calls(self, config) -> int:
+        """Clean up "orphan" tool-call records left in the conversation
+        history by failed tool executions.
+
+        Background: when the LLM asks to call a tool, LangGraph records
+        an AIMessage with a `tool_calls` list. Normally this is followed
+        by a ToolMessage holding the tool's response. Most LLM providers
+        require this pairing — every tool_call must have a matching
+        ToolMessage *immediately* after the AIMessage that asked for it.
+
+        What goes wrong: if a tool execution crashes (network error,
+        timeout, etc.) the AIMessage gets persisted but no ToolMessage
+        follows. Then the user types another message, and now we send
+        the LLM a history with [..., AIMessage(tool_calls), HumanMessage]
+        — invalid sequence. Provider rejects it with INVALID_CHAT_HISTORY.
+
+        Two ways to fix this:
+          1. Append a fake ToolMessage at the end of history. Doesn't
+             work — providers require IMMEDIATE adjacency, not
+             eventual presence.
+          2. Remove the orphan AIMessage entirely. Works — gap closes,
+             history becomes valid again. We use RemoveMessage, which
+             LangGraph's add_messages reducer recognizes as a deletion
+             marker."""
+        if not self.graph or not config:
+            return 0
+        try:
+            state = await self.graph.aget_state(config)
+        except Exception as e:
+            logger.debug("Could not fetch state for orphan check: %s", e)
+            return 0
+
+        messages = state.values.get("messages", []) if state and state.values else []
+        if not messages:
+            return 0
+
+        expected, fulfilled = set(), set()
+        for msg in messages:
+            for tc in getattr(msg, "tool_calls", None) or []:
+                tcid = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tcid:
+                    expected.add(tcid)
+            tcid = getattr(msg, "tool_call_id", None)
+            if tcid:
+                fulfilled.add(tcid)
+
+        orphans = expected - fulfilled
+        if not orphans:
+            return 0
+
+        # Remove every AIMessage that contains an orphan tool_call. We use
+        # RemoveMessage here (recognized by langgraph's add_messages reducer)
+        # instead of appending healing ToolMessages, because providers
+        # require ToolMessages to immediately follow their AIMessage —
+        # appending at the end of history breaks that ordering rule.
+        removals = []
+        for msg in messages:
+            msg_tc_ids = set()
+            for tc in getattr(msg, "tool_calls", None) or []:
+                tcid = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+                if tcid:
+                    msg_tc_ids.add(tcid)
+            if msg_tc_ids & orphans:
+                msg_id = getattr(msg, "id", None)
+                if msg_id:
+                    removals.append(RemoveMessage(id=msg_id))
+
+        if not removals:
+            logger.warning(
+                "Detected %d orphan tool_call(s) but messages have no .id "
+                "to remove them by; cannot heal automatically",
+                len(orphans),
+            )
+            return 0
+
+        logger.warning(
+            "Removing %d orphan AIMessage(s) (cleared %d unmatched tool_call ids: %s)",
+            len(removals), len(orphans), list(orphans),
+        )
+        await self.graph.aupdate_state(config, {"messages": removals})
+        return len(removals)
+
+    # ── Diagnostics & friendly messages ─────────────────────────
+    def _runtime_diagnostics(self) -> str:
+        lines = [
+            f"Path.home() = {Path.home()}",
+            f"euid/uid    = {os.geteuid()}/{os.getuid()}",
+            f"USER env    = {os.environ.get('USER', '<unset>')}",
+            f"cwd         = {Path.cwd()}",
+            f"clock epoch = {int(time.time())}",
+            "",
+            f"enabled     : ADB={ADB_ENABLED}  OAC={OAC_ENABLED}  OIC={OIC_ENABLED}",
+        ]
+        if OAC_ENABLED:
+            lines.append(
+                f"OAC_PRIVATE_KEY: {OAC_PRIVATE_KEY} "
+                f"({'EXISTS' if OAC_PRIVATE_KEY.exists() else 'MISSING'})"
+            )
+            try:
+                access = self._oac_access_token or ""
+                if access and access.count(".") == 2:
+                    payload_b64 = access.split(".")[1]
+                    payload_b64 += "=" * (-len(payload_b64) % 4)
+                    payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+                    now = int(time.time())
+                    exp = payload.get("exp")
+                    lines.append("")
+                    lines.append("In-memory OAC access token:")
+                    lines.append(f"  first 30 : {access[:30]}...")
+                    lines.append(f"  iat/exp  : {payload.get('iat')} / {exp}")
+                    if exp:
+                        delta = exp - now
+                        lines.append(
+                            f"  ⚠ EXPIRED ({-delta}s ago)" if delta < 0
+                            else f"  ✓ valid for {delta}s"
+                        )
+            except Exception as e:
+                lines.append(f"  (couldn't decode access_token: {e})")
+        return "\n".join(lines)
+
+    def _friendly_auth_message(self, exc: Exception) -> str | None:
+        """Detect which integration's auth failed (by URL fragments / error
+        shape) and return a per-source recovery message. Returns None if
+        we can't classify the error — caller falls back to generic."""
+        text = str(exc)
+        text_lc = text.lower()
+
+        # OAC JWT assertion — IDCS errors at /oauth2/v1/token, plus MCP
+        # endpoint failures. We match by exact OAC token URL when we have
+        # one; otherwise fall back to the generic IDCS path heuristic.
+        if OAC_ENABLED:
+            hit_oac_token_endpoint = bool(OAC_TOKEN_URL) and OAC_TOKEN_URL in text
+            if hit_oac_token_endpoint:
+                if "invalid_grant" in text_lc:
+                    return self._oac_jwt_message(
+                        "IDCS rejected the user assertion (invalid_grant) — "
+                        "service user disabled, missing, or wrong email."
+                    )
+                if "invalid_client" in text_lc:
+                    return self._oac_jwt_message(
+                        "IDCS rejected the client assertion (invalid_client) — "
+                        "cert not registered on the Confidential App, or wrong client_id."
+                    )
+                if "invalid_request" in text_lc or "signature" in text_lc:
+                    return self._oac_jwt_message(
+                        "IDCS rejected the JWT (invalid_request / signature) — "
+                        "malformed JWT, wrong private key, or clock skew > 5 min."
+                    )
+                if "401" in text:
+                    return self._oac_jwt_message(
+                        "IDCS returned 401 on the JWT-bearer exchange — "
+                        "check the Confidential App is Active and the cert is registered."
+                    )
+            if "/api/mcp" in text_lc and any(s in text for s in ("401", "403")):
+                return self._oac_jwt_message(
+                    "OAC's MCP endpoint rejected the access token. The JWT exchange "
+                    "succeeded but the resulting bearer lacks permission — verify the "
+                    "service user has access to the OAC datasets/subject areas."
+                )
+
+        # OIC — IDCS token endpoint or MCP endpoint failures
+        if OIC_ENABLED:
+            if "/oauth2/v1/token" in text_lc:
+                if "invalid_scope" in text_lc:
+                    return self._oic_message(
+                        "OIC OAuth rejected the scope (invalid_scope).",
+                        focus="scope",
+                    )
+                if "invalid_client" in text_lc or "inactive" in text_lc:
+                    return self._oic_message(
+                        "OIC OAuth rejected the client (invalid_client / inactive app).",
+                        focus="client",
+                    )
+                if "401" in text:
+                    return self._oic_message(
+                        "OIC OAuth returned 401 — wrong client_id / client_secret.",
+                        focus="client",
+                    )
+                return self._oic_message(
+                    f"OIC OAuth call failed: {text[:200]}", focus="client",
+                )
+            if "/mcp-server/" in text_lc:
+                if "403" in text:
+                    return self._oic_message(
+                        "OIC MCP returned 403 Forbidden — the token is valid but lacks "
+                        "permission. Almost certainly the ServiceInvoker role mapping.",
+                        focus="role",
+                    )
+                if "404" in text:
+                    return self._oic_message(
+                        "OIC MCP returned 404 — wrong project ID, or 'Enable MCP server' "
+                        "is off on the project.",
+                        focus="project",
+                    )
+
+        # ADB — auth endpoint or MCP endpoint failures
+        if ADB_ENABLED:
+            if "/adb/auth/" in text_lc and "401" in text:
+                return self._adb_message(
+                    "ADB rejected the password-grant credentials (401)."
+                )
+            if "/adb/mcp/" in text_lc and any(s in text for s in ("401", "403")):
+                return self._adb_message(
+                    "ADB MCP rejected the access token. Token may have expired between "
+                    "fetch and use, or the user lacks Select AI execute privileges."
+                )
+            if "/adb/" in text_lc and "404" in text:
+                return self._adb_message(
+                    "ADB endpoint returned 404 — likely wrong OCID or region."
+                )
+
+        return None
+
+    @staticmethod
+    def _oac_jwt_message(reason: str) -> str:
+        return (
+            "🔑 OAC JWT authentication failed.\n\n"
+            f"Reason: {reason}\n\n"
+            "How to fix:\n"
+            "  1. Verify the Confidential App in your OCI Identity Domain:\n"
+            "       • Status is Active\n"
+            "       • 'JWT Assertion' grant type is enabled\n"
+            "       • Your X.509 cert (oac-cert.pem) is registered as a\n"
+            "         Trusted Client on the app\n"
+            "  2. Verify integrations.oac in config.yaml:\n"
+            "       • client_id matches the Confidential App\n"
+            "       • idcs_host matches your OCI Identity Domain\n"
+            "       • service_user_email is an Active OAC user with the\n"
+            "         permissions you want the agent to inherit\n"
+            "  3. Verify the private key file (default: oac-jwt-key.txt) is\n"
+            "     uploaded next to agent.py and matches the cert registered\n"
+            "     in IDCS.\n"
+            "  4. Use mint-and-exchange.py locally to test the full chain\n"
+            "     before redeploying the agent.\n"
+            "  5. Redeploy after fixing.\n"
+        )
+
+    @staticmethod
+    def _oic_message(reason: str, focus: str) -> str:
+        steps = {
+            "role": (
+                "  1. OCI Console → Identity → Domains → your domain →\n"
+                "     Oracle Cloud Services → your OIC instance → Application Roles\n"
+                "  2. Open ServiceInvoker → Assigned applications → assign the\n"
+                "     Confidential App referenced in config.yaml (integrations.oic.client_id)\n"
+                "  3. Save. The role propagates within ~60 seconds.\n"
+                "  4. Re-send your message — no redeploy needed.\n"
+                "\n"
+                "Note: ServiceAdministrator alone is NOT enough — MCP requires ServiceInvoker."
+            ),
+            "scope": (
+                "  1. Open the Confidential App in your OCI Identity Domain\n"
+                "  2. OAuth Configuration → Token issuance policy → Resources\n"
+                "  3. Copy BOTH scope values verbatim (urn:opc:resource:consumer::all\n"
+                "     AND /ic/api/) — they use the IDCS-registered hash hostname,\n"
+                "     NOT the user-facing design.* hostname\n"
+                "  4. Paste them space-separated into integrations.oic.scope in config.yaml\n"
+                "  5. Redeploy.\n"
+            ),
+            "client": (
+                "  1. Verify integrations.oic.client_id and client_secret in config.yaml\n"
+                "     match an Active Confidential Application in your OCI Identity Domain\n"
+                "  2. App detail page → status badge should say 'Active'. If 'Inactive':\n"
+                "     Actions → Activate.\n"
+                "  3. Allowed grant types must include 'Client Credentials'.\n"
+                "  4. Redeploy after fixing.\n"
+            ),
+            "project": (
+                "  1. OIC Designer → open the project → pencil/Edit (top right) →\n"
+                "     ☑ Enable MCP server → Save\n"
+                "  2. Verify integrations.oic.mcp_url in config.yaml matches the URL shown\n"
+                "     after saving. Canonical pattern:\n"
+                "     https://<host>/mcp-server/v1/projects/<projectId>/mcp\n"
+                "  3. Redeploy.\n"
+            ),
+        }[focus]
+        return (
+            "🔑 OIC authentication / authorization failed.\n\n"
+            f"Reason: {reason}\n\n"
+            "How to fix:\n"
+            f"{steps}"
+        )
+
+    @staticmethod
+    def _adb_message(reason: str) -> str:
+        return (
+            "🔑 ADB authentication failed.\n\n"
+            f"Reason: {reason}\n\n"
+            "How to fix:\n"
+            "  1. Verify integrations.adb in config.yaml: ocid, region, user, password\n"
+            "  2. Sanity check by logging into the same ADB via SQL Developer Web with\n"
+            "     the same user/password\n"
+            "  3. Confirm the user has Select AI privileges:\n"
+            "       GRANT EXECUTE ON DBMS_CLOUD_AI TO <user>;\n"
+            "  4. Redeploy after fixing config.yaml\n"
+        )
+
+    # ── Invoke (per user message) ───────────────────────────────
+    async def invoke(self, user_query: str, **kwargs):
+        """Called by AIDP for every chat message. The high-level flow:
+
+        1. Bail out early if setup() captured an error (config or auth
+           setup failed) — return that error as the chat reply.
+        2. Run pre_invoke_setup() to configure auth context for OCI
+           Generative AI.
+        3. Lazy-load MCP tools the very first time we're invoked.
+        4. Heal any orphan tool_calls left in conversation state by
+           previously-failed tool executions.
+        5. Run the actual react-agent graph.
+        6. If the graph errored with something recoverable (auth/network),
+           rebuild MCP, heal orphans, and retry once.
+
+        There is NO scheduled token refresh. Every Oracle service we hit
+        can be re-authenticated on demand from cached config + private
+        key, with no rotating refresh chain to keep alive. When a tool
+        call hits 401, step 6 mints a fresh bearer and retries — that's
+        the entire freshness story."""
+
+        # ─── Step 1: surface setup-time errors ─────────────────────
+        if self._self_stage_error:
+            return {"messages": [{"role": "ai", "content":
+                f"Self-stage failed at setup:\n{self._self_stage_error}\n\n"
+                f"Runtime diagnostics:\n{self._runtime_diagnostics()}"
+            }]}
+
+        # ─── Step 2: AIDP auth context for OCI Gen AI ──────────────
+        # pre_invoke_setup wires the OCI signer into the request thread so
+        # the LLM's HTTP calls get signed correctly. If it errors we soldier
+        # on with an empty config — chat may still partially work.
+        try:
+            config = pre_invoke_setup(**kwargs)
+        except Exception as e:
+            logger.warning("pre_invoke_setup failed, using empty config: %s", e)
+            config = {}
+
+        # asyncio.Lock has to be created INSIDE a running event loop.
+        # That's why we lazy-init here on the first invoke instead of
+        # in __init__ (which runs at module import time, no loop).
+        if self._load_lock is None:
+            self._load_lock = asyncio.Lock()
+
+        # ─── Step 3: lazy first-load of MCP tools ──────────────────
+        # We don't load MCP at setup() time because setup is sync and MCP
+        # loading is async. So the first chat message pays a one-time cost
+        # of opening sessions and discovering tools. Subsequent messages
+        # use the cached graph until something forces a rebuild (token
+        # expiry caught by reactive retry in Step 6).
+        # Double-checked locking: outer check is the fast path, the inner
+        # check inside the lock prevents two concurrent first-invokes from
+        # both running the load.
+        if not self._tools_loaded:
+            async with self._load_lock:
+                if not self._tools_loaded:
+                    try:
+                        await self._load_all_mcp_tools()
+                    except Exception as e:
+                        logger.error("MCP tool load failed: %s", e, exc_info=True)
+                        friendly = self._friendly_auth_message(e)
+                        if friendly:
+                            return {"messages": [{"role": "ai", "content": friendly}]}
+                        return {"messages": [{"role": "ai", "content":
+                            f"MCP setup error: {type(e).__name__}: {e}\n\n"
+                            f"Runtime diagnostics:\n{self._runtime_diagnostics()}\n\n"
+                            f"Stack trace (last 800 chars):\n{traceback.format_exc()[-800:]}"
+                        }]}
+
+        # ─── Step 4: heal orphan tool_calls from prior failures ────
+        try:
+            await self._heal_orphan_tool_calls(config)
+        except Exception as e:
+            logger.warning("Orphan healing failed (continuing): %s", e)
+
+        # ─── Step 5: run the react-agent graph ─────────────────────
+        # The graph handles the LLM ↔ tool-call ↔ LLM dance. It runs to
+        # completion (final answer or error) before returning here.
+        user_message = HumanMessage(content=user_query)
+        messages = {"messages": [dict(user_message)]}
+
+        try:
+            return await self.graph.ainvoke(messages, config=config)
+        except Exception as e:
+            # ─── Step 6: reactive recovery ────────────────────────
+            # If the failure looks transient (auth/network), try once more
+            # after rebuilding MCP. This catches the common case where a
+            # token expired in flight or a TCP socket got dropped.
+            if _is_recoverable_error(e):
+                logger.warning(
+                    "Recoverable error mid-invoke (%s); rebuilding MCP and retrying",
+                    type(e).__name__,
+                )
+                try:
+                    # Rebuild under the lock so concurrent invokes don't
+                    # both kick off a rebuild.
+                    async with self._load_lock:
+                        if OAC_ENABLED:
+                            await self._refresh_oac_token_and_rebuild()
+                        else:
+                            await self._load_all_mcp_tools()
+                    # The failed call may have left an orphan tool_call in
+                    # conversation state — heal it before retrying or the
+                    # LLM provider will reject the request.
+                    try:
+                        await self._heal_orphan_tool_calls(config)
+                    except Exception as heal_err:
+                        logger.warning("Orphan healing on retry failed: %s", heal_err)
+                    return await self.graph.ainvoke(messages, config=config)
+                except Exception as e2:
+                    # Retry also failed. Surface a friendly message if
+                    # we can identify the auth issue, else dump diagnostics.
+                    friendly = self._friendly_auth_message(e2)
+                    if friendly:
+                        return {"messages": [{"role": "ai", "content": friendly}]}
+                    logger.error("Retry after rebuild failed: %s", e2, exc_info=True)
+                    return {"messages": [{"role": "ai", "content":
+                        f"Agent error after rebuild retry: {type(e2).__name__}: {e2}\n\n"
+                        f"Runtime diagnostics:\n{self._runtime_diagnostics()}"
+                    }]}
+
+            # Non-recoverable error path: log it and return the error text.
+            # User sees a friendly-ish "Agent error: ..." message.
+            logger.error("invoke error: %s", e, exc_info=True)
+            return {"messages": [{"role": "ai", "content":
+                f"Agent error: {type(e).__name__}: {e}"
+            }]}

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/agent.py
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/agent.py
@@ -455,6 +455,24 @@ def _is_auth_error(e: Exception) -> bool:
     return any(s in msg for s in ("401", "403", "unauthorized", "forbidden", "expired"))
 
 
+def _is_invalid_history(e: BaseException) -> bool:
+    """True when the error is LangGraph's INVALID_CHAT_HISTORY — i.e. an
+    AIMessage with tool_calls but no matching ToolMessage. Happens when a
+    tool execution gets interrupted (typical cause: AIDP suspends the
+    agent process mid-call). Our normal `_heal_orphan_tool_calls` handles
+    most of these, but it can fail when the persisted AIMessage has no
+    `.id` we can target with RemoveMessage. Recovery for that case is a
+    hard state wipe — handled in invoke()."""
+    sub_exceptions = getattr(e, "exceptions", None)
+    if sub_exceptions:
+        return any(_is_invalid_history(sub) for sub in sub_exceptions)
+    msg = str(e)
+    return (
+        "INVALID_CHAT_HISTORY" in msg
+        or "tool_calls that do not have a corresponding ToolMessage" in msg
+    )
+
+
 def _is_recoverable_error(e: BaseException) -> bool:
     """Decide whether a failed invoke is worth retrying after rebuilding
     the MCP stack. We retry on:
@@ -706,6 +724,40 @@ class AgentBasic:
         logger.warning(
             "Removing %d orphan AIMessage(s) (cleared %d unmatched tool_call ids: %s)",
             len(removals), len(orphans), list(orphans),
+        )
+        await self.graph.aupdate_state(config, {"messages": removals})
+        return len(removals)
+
+    async def _hard_clear_history(self, config) -> int:
+        """Last-resort recovery: remove EVERY message from conversation state.
+        Used when `_heal_orphan_tool_calls` couldn't fix an INVALID_CHAT_HISTORY
+        situation (typically because some persisted AIMessage has no `.id` for
+        targeted removal). Loses conversation history but the next message
+        starts from a clean slate. Returns the number of messages cleared."""
+        if not self.graph or not config:
+            return 0
+        try:
+            state = await self.graph.aget_state(config)
+        except Exception as e:
+            logger.debug("Could not fetch state for hard clear: %s", e)
+            return 0
+
+        messages = state.values.get("messages", []) if state and state.values else []
+        if not messages:
+            return 0
+
+        removals = []
+        for msg in messages:
+            msg_id = getattr(msg, "id", None)
+            if msg_id:
+                removals.append(RemoveMessage(id=msg_id))
+
+        if not removals:
+            return 0
+
+        logger.warning(
+            "Hard-clearing %d message(s) from conversation state (last-resort recovery)",
+            len(removals),
         )
         await self.graph.aupdate_state(config, {"messages": removals})
         return len(removals)
@@ -1035,20 +1087,60 @@ class AgentBasic:
                         logger.warning("Orphan healing on retry failed: %s", heal_err)
                     return await self.graph.ainvoke(messages, config=config)
                 except Exception as e2:
-                    # Retry also failed. Surface a friendly message if
-                    # we can identify the auth issue, else dump diagnostics.
+                    # Retry also failed. Surface a friendly auth message if
+                    # we can classify it as an identifiable auth issue.
                     friendly = self._friendly_auth_message(e2)
                     if friendly:
                         return {"messages": [{"role": "ai", "content": friendly}]}
+                    # If the retry hit INVALID_CHAT_HISTORY (orphan tool_call
+                    # we couldn't heal), do a hard state wipe and try ONE more
+                    # time. Loses prior conversation memory but recovers
+                    # automatically.
+                    if _is_invalid_history(e2):
+                        logger.warning(
+                            "Retry hit INVALID_CHAT_HISTORY — hard-clearing state and trying once more"
+                        )
+                        try:
+                            await self._hard_clear_history(config)
+                            return await self.graph.ainvoke(messages, config=config)
+                        except Exception as e3:
+                            logger.error("Hard-clear retry also failed: %s", e3, exc_info=True)
                     logger.error("Retry after rebuild failed: %s", e2, exc_info=True)
                     return {"messages": [{"role": "ai", "content":
-                        f"Agent error after rebuild retry: {type(e2).__name__}: {e2}\n\n"
-                        f"Runtime diagnostics:\n{self._runtime_diagnostics()}"
+                        self._try_again_message()
                     }]}
 
-            # Non-recoverable error path: log it and return the error text.
-            # User sees a friendly-ish "Agent error: ..." message.
+            # INVALID_CHAT_HISTORY caught directly (no recoverable error
+            # preceded it). Same hard-clear + retry path.
+            if _is_invalid_history(e):
+                logger.warning(
+                    "INVALID_CHAT_HISTORY mid-invoke — hard-clearing state and retrying"
+                )
+                try:
+                    await self._hard_clear_history(config)
+                    return await self.graph.ainvoke(messages, config=config)
+                except Exception as e2:
+                    logger.error("Hard-clear retry failed: %s", e2, exc_info=True)
+                return {"messages": [{"role": "ai", "content":
+                    self._try_again_message()
+                }]}
+
+            # Non-recoverable, unclassified error path: log full detail for
+            # ops, but only show the user a friendly retry message.
             logger.error("invoke error: %s", e, exc_info=True)
             return {"messages": [{"role": "ai", "content":
-                f"Agent error: {type(e).__name__}: {e}"
+                self._try_again_message()
             }]}
+
+    @staticmethod
+    def _try_again_message() -> str:
+        """Friendly message shown to the user when the agent couldn't complete
+        the request after all internal retries. Hides the technical details
+        (logged separately for ops) and tells the user to try again."""
+        return (
+            "I ran into a problem completing that request and couldn't recover "
+            "from it automatically. Please try sending your message again — if "
+            "the issue persists for a few minutes, the connected services "
+            "(database, analytics, integrations) may be having trouble. The "
+            "agent's logs have full details for diagnostics."
+        )

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/agent.py
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/agent.py
@@ -20,10 +20,16 @@ Quick architecture:
         - OAC:  JWT Bearer / User Assertion (RFC 7523), local-signed
                 from a long-lived private key
         - OIC:  client_credentials (RFC 6749 §4.4)
-    So we don't run any background refresh loop. Tokens get rebuilt
-    only when a tool call fails with 401/connection error — the
-    reactive retry in invoke() catches that, mints fresh bearers,
-    and retries.
+    So we don't run any background refresh loop.
+  • OAC's access_token has a 5-minute TTL — short enough that AIDP's
+    idle-suspend can wake the agent up with a long-expired bearer
+    cached in MCP's headers. To handle that, every invoke() runs
+    _ensure_fresh_oac_token() at the top, which checks the cached
+    JWT's exp claim and mints a fresh one if there's <60s remaining.
+    Cheap when fresh (one JWT decode); ~300ms refresh when needed.
+  • If a tool call still fails with 401/connection error despite the
+    proactive refresh, the reactive retry in invoke() catches that,
+    rebuilds MCP, heals any orphan tool_calls, and retries once.
 """
 
 import asyncio
@@ -645,6 +651,74 @@ class AgentBasic:
         logger.info("OAC access_token minted via JWT assertion")
         await self._load_all_mcp_tools()
 
+    def _oac_token_seconds_remaining(self) -> int:
+        """Decode the cached OAC JWT's `exp` claim and return seconds left
+        before it expires. Returns -1 if no token is cached or the claim
+        can't be parsed — callers treat that as 'expired' and refresh."""
+        access = self._oac_access_token or ""
+        if not access or access.count(".") != 2:
+            return -1
+        try:
+            payload_b64 = access.split(".")[1]
+            payload_b64 += "=" * (-len(payload_b64) % 4)
+            payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+            exp = payload.get("exp")
+            if not exp:
+                return -1
+            return int(exp - time.time())
+        except Exception:
+            return -1
+
+    # OAC's IDCS-issued access_tokens have a 5-minute TTL. If our cached
+    # token has less than this many seconds remaining, mint a fresh one
+    # before the LLM's next tool call. 60s is comfortably above any
+    # plausible call duration and gives us a small buffer against clock
+    # skew between the agent host and OAC.
+    OAC_TOKEN_REFRESH_THRESHOLD_SECS = 60
+
+    async def _ensure_fresh_oac_token(self) -> None:
+        """If the cached OAC token is expired or close to expiring, mint a
+        fresh one and (if MCP was already built) rebuild MCP so the new
+        bearer takes effect. Cheap (just a JWT decode) when the token is
+        fresh — safe to call at the top of every invoke.
+
+        Why this is the right freshness mechanism:
+          - OAC tokens have a 5-minute TTL. AIDP suspends the agent process
+            during idle; after hours of idle, the cached bearer baked into
+            the MCP client headers is hopelessly expired and the first
+            tool call would fail with 401.
+          - Refreshing on-demand at the start of each invoke catches this
+            without scheduled background work (which wouldn't tick anyway
+            during AIDP idle suspension).
+          - We refresh proactively when there's less than ~60s remaining
+            so the LLM's chained tool calls during a single user turn
+            (discover → describe → execute) all use the same fresh token
+            without us having to refresh mid-turn."""
+        if not OAC_ENABLED:
+            return
+        seconds_left = self._oac_token_seconds_remaining()
+        if seconds_left > self.OAC_TOKEN_REFRESH_THRESHOLD_SECS:
+            return
+        logger.info(
+            "OAC token has %ds remaining (≤%ds threshold) — refreshing",
+            seconds_left, self.OAC_TOKEN_REFRESH_THRESHOLD_SECS,
+        )
+        async with self._load_lock:
+            # Double-check inside the lock — another concurrent invoke may
+            # have refreshed already and updated the cached token.
+            if self._oac_token_seconds_remaining() > self.OAC_TOKEN_REFRESH_THRESHOLD_SECS:
+                return
+            if self._tools_loaded:
+                # MCP is already built with the stale bearer; rebuild it.
+                await self._refresh_oac_token_and_rebuild()
+            else:
+                # Lazy first-load hasn't run yet. Just update the cached
+                # token — the upcoming first-load will pick it up.
+                self._oac_access_token = await asyncio.to_thread(
+                    _fetch_oac_access_token, self._oac_private_key
+                )
+                logger.info("OAC token refreshed (MCP not yet built; will be used at first build)")
+
     # ── Conversation state healing ──────────────────────────────
     async def _heal_orphan_tool_calls(self, config) -> int:
         """Clean up "orphan" tool-call records left in the conversation
@@ -985,6 +1059,8 @@ class AgentBasic:
            setup failed) — return that error as the chat reply.
         2. Run pre_invoke_setup() to configure auth context for OCI
            Generative AI.
+        2.5. Refresh the OAC bearer if it's expired or about to expire
+           (5-minute token TTL — handles AIDP suspend-then-wake gaps).
         3. Lazy-load MCP tools the very first time we're invoked.
         4. Heal any orphan tool_calls left in conversation state by
            previously-failed tool executions.
@@ -994,9 +1070,9 @@ class AgentBasic:
 
         There is NO scheduled token refresh. Every Oracle service we hit
         can be re-authenticated on demand from cached config + private
-        key, with no rotating refresh chain to keep alive. When a tool
-        call hits 401, step 6 mints a fresh bearer and retries — that's
-        the entire freshness story."""
+        key, with no rotating refresh chain to keep alive. The proactive
+        check in step 2.5 handles the common case (AIDP idle for hours,
+        cached OAC token expired); step 6 catches the rest."""
 
         # ─── Step 1: surface setup-time errors ─────────────────────
         if self._self_stage_error:
@@ -1020,6 +1096,17 @@ class AgentBasic:
         # in __init__ (which runs at module import time, no loop).
         if self._load_lock is None:
             self._load_lock = asyncio.Lock()
+
+        # ─── Step 2.5: refresh OAC token if it's about to expire ─────
+        # OAC tokens have a 5-minute TTL. AIDP suspends the agent during
+        # idle, so a session that was warm hours ago will have a long-
+        # expired bearer. Mint a fresh one before the LLM ever sees
+        # OAC. Cheap when the token is fresh (one JWT decode); a single
+        # JWT-bearer exchange (~300ms) when refresh is needed.
+        try:
+            await self._ensure_fresh_oac_token()
+        except Exception as e:
+            logger.warning("OAC token freshness check failed (continuing): %s", e)
 
         # ─── Step 3: lazy first-load of MCP tools ──────────────────
         # We don't load MCP at setup() time because setup is sync and MCP

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/config.sample.yaml
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/config.sample.yaml
@@ -94,10 +94,17 @@ integrations:
   # How the agent uses this at runtime:
   #   • At deploy: stages oac-jwt-key.txt → $HOME/oac-mcp/jwt-signing.pem,
   #     loads the private key, mints the first access_token.
-  #   • No background refresh loop. When a tool call fails with 401, the
+  #   • Proactive freshness check at the top of every invoke(): OAC's
+  #     access_tokens have a short 5-minute TTL and AIDP suspends the
+  #     agent during idle, so the cached bearer goes stale fast. The
+  #     agent decodes the cached token's exp claim — if ≤60s remain it
+  #     mints a fresh JWT, exchanges it at IDCS, and rebuilds MCP before
+  #     the LLM sees OAC. Cheap when the token is fresh (one JWT decode).
+  #   • Reactive retry as a safety net. If a tool call still fails with
+  #     401 (e.g. a slow tool outlives the freshly minted bearer), the
   #     reactive-retry path mints a fresh JWT, rebuilds MCP, and retries
-  #     the same message. The user sees ~1-2s of extra latency once after
-  #     a long idle, but never a failed message.
+  #     the same message. The user sees ~1-2s of extra latency at worst,
+  #     never a failed message.
   #
   # The only operational break point is key rotation — you choose the
   # cadence (annual is generous). When you rotate, generate a new keypair,

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/config.sample.yaml
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/config.sample.yaml
@@ -1,0 +1,171 @@
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  Multi-MCP Chat Agent — configuration                            ║
+# ║                                                                  ║
+# ║  Copy this file to config.yaml and fill in your values.          ║
+# ║  Set 'enabled: false' on any integration you don't want to use.  ║
+# ║  See README.md for full setup steps.                             ║
+# ╚══════════════════════════════════════════════════════════════════╝
+
+
+# ─── LLM (always required) ─────────────────────────────────────────
+# OCI Generative AI is the LLM backend. The agent uses the OCI signer
+# principal injected by AIDP — no API key needed.
+#
+#   1. Pick a compartment on-listed for OCI Generative AI in your region.
+#   2. Choose any chat-capable model. xai.grok-4-fast-non-reasoning is a
+#      solid default.
+llm:
+  compartment_id: ocid1.compartment.oc1..your-compartment-ocid
+  region: us-ashburn-1
+  model_id: xai.grok-4-fast-non-reasoning
+
+
+integrations:
+
+  # ─── ADB Select AI MCP ───────────────────────────────────────────
+  # Exposes a Select AI tool from your database as an MCP tool.
+  # Assumes you already have an ADB instance with data, version 19.29+
+  # or 23.26+ (older versions don't support Select AI MCP).
+  #
+  # Two pieces are required — both must be done:
+  #
+  # 1. Enable MCP on the ADB instance (OCI Console, REQUIRED FIRST):
+  #      OCI Console → Autonomous Database → your ADB → Tags → Add tag.
+  #      Tag namespace: free-form
+  #      Tag key:       adb$feature
+  #      Tag value:     {"name":"mcp_server","enable":true}
+  #      Save. Without this tag the MCP endpoint is not exposed at all.
+  #
+  # 2. Create profile + tool inside the database:
+  #      Use enable-mcp-selectai.sql as a starting point. Run it as ADMIN
+  #      from SQL Developer Web. The template:
+  #        - Calls DBMS_CLOUD_ADMIN.ENABLE_RESOURCE_PRINCIPAL() so ADB
+  #          can call OCI Generative AI as itself
+  #        - Creates a Select AI profile (provider=oci, credential=
+  #          OCI$RESOURCE_PRINCIPAL) auto-discovering schema tables
+  #        - Registers an MCP tool via DBMS_CLOUD_AI_AGENT.CREATE_TOOL
+  #          (with COMMIT — required on some ADB versions)
+  #        - Smoke tests with DBMS_CLOUD_AI.GENERATE
+  #
+  # Endpoint URL becomes live ~1 minute after the OCI tag is saved AND
+  # at least one tool is registered:
+  #   https://dataaccess.adb.<region>.oraclecloudapps.com/adb/mcp/v1/databases/<adb_ocid>
+  #
+  # Auth: OAuth 2.0 Resource Owner Password Credentials grant ("password
+  # grant"). Bearer is fetched fresh on every MCP rebuild cycle — no
+  # token persistence needed.
+  adb:
+    enabled: true
+    ocid: ocid1.autonomousdatabase.oc1.iad.your-adb-ocid
+    region: us-ashburn-1
+    user: admin
+    password: your-adb-password
+
+  # ─── OAC MCP ─────────────────────────────────────────────────────
+  # Auth uses OAuth 2.0 JWT User Assertion. The agent locally signs a
+  # short-lived JWT, exchanges it at IDCS for an OAC access_token, and
+  # uses that bearer to call /api/mcp. There's NO rotating refresh token
+  # — every access_token is freshly minted, so the chain can't break
+  # overnight (the original failure mode of the user-profile tokens.json
+  # flow).
+  #
+  # Assumes you already have datasets / subject areas in OAC.
+  #
+  # To enable MCP (one-time IDCS setup):
+  #   1. Generate keypair + X.509 cert on your laptop:
+  #        openssl genrsa -out oac-jwt-key.pem 2048
+  #        openssl req -x509 -key oac-jwt-key.pem -out oac-cert.pem \
+  #          -days 365 -subj "/CN=oac-mcp-agent"
+  #   2. In your OCI Identity Domain, on a Confidential Application
+  #      (you can reuse the OIC one or create a separate one):
+  #        • Allowed grant types must include "JWT Assertion"
+  #        • Upload oac-cert.pem under "Trusted Client Certificates"
+  #        • Activate the app
+  #   3. Pick or create a service user on OAC (e.g. oac-agent-svc@your-org.com)
+  #      and grant them the OAC permissions you want the agent to inherit.
+  #      All chat users will see data as this service user (no per-user RLS).
+  #   4. Verify the chain works locally with mint-and-exchange.py BEFORE
+  #      deploying the agent — fastest way to confirm the IDCS+OAC config.
+  #   5. Rename oac-jwt-key.pem → oac-jwt-key.txt (AIDP file picker
+  #      doesn't accept .pem; .txt is fine and treated as a binary file).
+  #   6. Upload oac-jwt-key.txt next to agent.py in your AIDP project.
+  #   7. Set 'enabled: true' and fill in the fields below.
+  #
+  # How the agent uses this at runtime:
+  #   • At deploy: stages oac-jwt-key.txt → $HOME/oac-mcp/jwt-signing.pem,
+  #     loads the private key, mints the first access_token.
+  #   • No background refresh loop. When a tool call fails with 401, the
+  #     reactive-retry path mints a fresh JWT, rebuilds MCP, and retries
+  #     the same message. The user sees ~1-2s of extra latency once after
+  #     a long idle, but never a failed message.
+  #
+  # The only operational break point is key rotation — you choose the
+  # cadence (annual is generous). When you rotate, generate a new keypair,
+  # re-register the cert in IDCS, re-upload the .txt, redeploy.
+  oac:
+    enabled: true
+    url: https://your-oac-host.analytics.ocp.oraclecloud.com
+    idcs_host: idcs-yourdomain.identity.oraclecloud.com
+    client_id: your-confidential-app-client-id
+    service_user_email: oac-agent-svc@your-org.com
+    # Scope: full OAC resource scope from the Token Issuance Policy → Resources
+    # table. Use the IDCS-registered hash hostname (e.g.
+    # "https://<hash>.analytics.ocp.oraclecloud.comurn:opc:resource:consumer::all"),
+    # NOT the user-facing OAC URL.
+    scope: https://<hash>.analytics.ocp.oraclecloud.comurn:opc:resource:consumer::all
+    # Cert alias: must match the Alias you set when importing oac-cert.pem
+    # in IDCS. Used as the JWT `kid` header so IDCS knows which trusted
+    # cert to verify the signature against.
+    cert_alias: oac-mcp
+    private_key_filename: oac-jwt-key.txt
+
+  # ─── OIC MCP ─────────────────────────────────────────────────────
+  # OIC's MCP server is per-project. Three orthogonal pieces — ALL must
+  # be in place or you get 403 / empty tool lists / invalid_scope.
+  #
+  # Assumes you already have an OIC 3 project with integrations.
+  #
+  # 1. Enable MCP on the project:
+  #      OIC Designer → open the project → pencil/Edit (top right) →
+  #      tick "Enable MCP server" → Save. Re-open Edit to copy the
+  #      MCP server URL. Canonical pattern:
+  #        https://<oic-host>/mcp-server/v1/projects/<projectId>/mcp
+  #
+  # 2. Register tools via the AI Agents tab:
+  #      Project sidebar → AI Agents → Tools → Add. The Integration
+  #      dropdown ONLY shows integrations that are REST-triggered,
+  #      activated, AND shared with other projects. Pick one, write a
+  #      clear description (the LLM uses it to decide when to call),
+  #      Save. Repeat for each integration you want exposed.
+  #
+  # 3. Confidential Application + ServiceInvoker role (auth chain):
+  #    a. In your OCI Identity Domain, create or reuse a Confidential
+  #       Application. Allowed grants must include Client Credentials.
+  #    b. OAuth Configuration → Token issuance policy → Resources → add
+  #       the OIC instance app. Add BOTH scopes:
+  #         • urn:opc:resource:consumer::all
+  #         • /ic/api/
+  #       Both use the IDCS-registered hash hostname (something like
+  #       1CE41DD5...integration.region.ocp.oraclecloud.com), NOT the
+  #       user-facing design.* hostname. Copy verbatim from the
+  #       Resources table.
+  #    c. Activate the application (Actions → Activate at the top of
+  #       the App detail page).
+  #    d. CRITICAL — map the app to ServiceInvoker on the OIC instance:
+  #       OCI Console → Identity → Domains → your domain → Oracle Cloud
+  #       Services → your OIC instance → Application Roles →
+  #       ServiceInvoker → Assigned applications → assign the
+  #       Confidential App. ServiceAdministrator alone is NOT enough —
+  #       MCP specifically requires ServiceInvoker.
+  #
+  # Auth: OAuth 2.0 client_credentials. Token TTL ~1h. No scheduled
+  # refresh — the agent re-fetches a fresh bearer on demand, triggered
+  # by the reactive-retry path when a tool call fails with 401.
+  oic:
+    enabled: true
+    mcp_url: https://your-oic-host.integration.your-region.ocp.oraclecloud.com/mcp-server/v1/projects/YOUR_PROJECT_ID/mcp
+    idcs_host: idcs-yourdomain.identity.oraclecloud.com
+    client_id: your-confidential-app-client-id
+    client_secret: your-confidential-app-client-secret
+    # Two scopes, space-separated, both using the IDCS-registered hash hostname:
+    scope: "https://<hash>.integration.<region>.ocp.oraclecloud.com:443urn:opc:resource:consumer::all https://<hash>.integration.<region>.ocp.oraclecloud.com:443/ic/api/"

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/enable-mcp-selectai.sql
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/enable-mcp-selectai.sql
@@ -1,0 +1,142 @@
+-- ============================================================
+-- SELECT AI + MCP SETUP TEMPLATE
+-- Oracle Autonomous Database (ADB)
+-- Run each block sequentially in SQL Worksheet (or SQL Developer Web)
+-- ============================================================
+--
+-- FILL IN BEFORE RUNNING:
+--   PROFILE_NAME  → e.g. 'NL2SQL_PROFILE' (line 53)
+--   SCHEMA_OWNER  → e.g. 'ADMIN'           (line 54)
+--   TOOL_NAME     → e.g. 'NL2SQL_TOOL'     (lines 99 / 107)
+--   SMOKE_TEST    → replace with a question about your data (line 121)
+--
+-- PREREQUISITES:
+--   - ADB instance running (19c v19.29+ or 26ai v23.26+)
+--   - MCP tag added to the ADB instance via OCI Console (Step 0 below)
+--   - Tables already loaded into the schema you point Select AI at
+-- ============================================================
+
+
+-- ============================================================
+-- STEP 0: ADD MCP TAG IN OCI CONSOLE (do this BEFORE running SQL)
+-- ============================================================
+-- OCI Console → Autonomous Database → your ADB instance
+-- Click Tags → Add tag:
+--   Tag namespace : (free-form)
+--   Tag key       : adb$feature
+--   Tag value     : {"name":"mcp_server","enable":true}
+-- Click Save.
+--
+-- This exposes the MCP endpoint at:
+--   https://dataaccess.adb.<region>.oraclecloudapps.com/adb/mcp/v1/databases/<adb_ocid>
+-- ============================================================
+
+
+-- STEP 1: Reset any manually created credential (safe to re-run)
+BEGIN
+  DBMS_CLOUD.DROP_CREDENTIAL(credential_name => 'OCI_CRED');
+EXCEPTION
+  WHEN OTHERS THEN NULL;
+END;
+/
+
+-- STEP 2: Enable resource principal authentication
+-- This lets ADB call OCI Generative AI using the database's own identity
+EXEC DBMS_CLOUD_ADMIN.ENABLE_RESOURCE_PRINCIPAL();
+
+-- STEP 3: Confirm credential was created automatically
+SELECT credential_name FROM user_credentials;
+-- You should see OCI$RESOURCE_PRINCIPAL in the results
+
+
+-- STEP 4: Create and enable Select AI profile
+-- Auto-discovers all tables in the schema — no hardcoding needed.
+-- Edit the profile name and schema owner below.
+DECLARE
+  l_profile_name CONSTANT VARCHAR2(100) := 'NL2SQL_PROFILE'; -- CHANGE
+  l_schema_owner CONSTANT VARCHAR2(100) := 'ADMIN';          -- CHANGE IF NEEDED
+  l_object_list  CLOB    := '[';
+  l_first        BOOLEAN := TRUE;
+BEGIN
+  BEGIN
+    DBMS_CLOUD_AI.DROP_PROFILE(profile_name => l_profile_name);
+  EXCEPTION
+    WHEN OTHERS THEN NULL;
+  END;
+
+  FOR r IN (
+    SELECT table_name FROM all_tables
+    WHERE owner = l_schema_owner
+    ORDER BY table_name
+  ) LOOP
+    IF NOT l_first THEN
+      l_object_list := l_object_list || ',';
+    END IF;
+    l_object_list := l_object_list || '{"owner":"' || l_schema_owner || '","name":"' || r.table_name || '"}';
+    l_first := FALSE;
+  END LOOP;
+
+  l_object_list := l_object_list || ']';
+
+  DBMS_CLOUD_AI.CREATE_PROFILE(
+    profile_name => l_profile_name,
+    attributes   => '{"provider":"oci","credential_name":"OCI$RESOURCE_PRINCIPAL","object_list":' || l_object_list || '}'
+  );
+
+  BEGIN
+    DBMS_CLOUD_AI.ENABLE_PROFILE(profile_name => l_profile_name);
+  EXCEPTION
+    WHEN OTHERS THEN NULL; -- profile may already be enabled on newer DB versions
+  END;
+
+  DBMS_OUTPUT.PUT_LINE('Profile created: ' || l_profile_name);
+  DBMS_OUTPUT.PUT_LINE('Tables included: ' || l_object_list);
+END;
+/
+
+
+-- STEP 5: Register MCP tool
+-- Change tool name and profile name to match Step 4.
+BEGIN
+  DBMS_CLOUD_AI_AGENT.DROP_TOOL(tool_name => 'NL2SQL_TOOL'); -- CHANGE
+EXCEPTION
+  WHEN OTHERS THEN NULL;
+END;
+/
+
+BEGIN
+  DBMS_CLOUD_AI_AGENT.CREATE_TOOL(
+    tool_name   => 'NL2SQL_TOOL',                                                       -- CHANGE
+    attributes  => '{"tool_type":"SQL","tool_params":{"profile_name":"NL2SQL_PROFILE"}}', -- CHANGE PROFILE NAME
+    status      => 'ENABLED',
+    description => 'Query the database using natural language.'                          -- OPTIONAL
+  );
+  COMMIT;  -- IMPORTANT: without this, tool registration silently fails to persist on some ADB versions.
+END;
+/
+
+-- STEP 6: Confirm tool registered
+-- View name varies across ADB versions. Try in order until one returns rows:
+SELECT * FROM user_cloud_ai_tools;        -- some versions
+-- SELECT * FROM user_cloud_ai_agent_tools;  -- other versions
+-- SELECT * FROM user_ai_agent_tools;        -- newest
+
+
+-- STEP 7: Smoke test (replace with a question about your data)
+SELECT DBMS_CLOUD_AI.GENERATE(
+  prompt       => 'How many account transactions do we have?', -- CHANGE
+  profile_name => 'NL2SQL_PROFILE',                            -- MATCH STEP 4
+  action       => 'runsql'
+) AS result FROM dual;
+
+
+-- ============================================================
+-- TROUBLESHOOTING
+-- ============================================================
+-- If `curl <mcp_url> tools/list` returns an empty list ({"tools":[]})
+-- even though Step 6 shows the tool is registered:
+--   → MCP server caches the tool registry at startup. Force a refresh:
+--     OCI Console → Autonomous Database → your ADB → More actions →
+--     Stop, wait ~30s, then Start. The MCP sidecar re-reads the
+--     registry on boot and the tool will show up in tools/list.
+-- ============================================================

--- a/ai/agent-flows/code-first/multi-mcp-chat-agent/mint-and-exchange.py
+++ b/ai/agent-flows/code-first/multi-mcp-chat-agent/mint-and-exchange.py
@@ -1,0 +1,140 @@
+"""
+Local verification helper for OAC's JWT User Assertion flow.
+
+Run this on your laptop BEFORE deploying the agent. It mints the two
+JWT assertions (client + user), exchanges them at IDCS for an OAC
+access_token, and prints both the token and a curl one-liner to test
+it against /api/mcp.
+
+If this script succeeds end-to-end, the IDCS-side configuration
+(Confidential App, JWT Assertion grant, registered cert, scopes,
+service user) is correct and the agent rewrite will Just Work.
+
+If it fails, fix IDCS first — don't bother debugging agent.py.
+
+Usage:
+  1. openssl genrsa -out oac-jwt-key.pem 2048
+  2. openssl req -x509 -key oac-jwt-key.pem -out oac-cert.pem \\
+       -days 365 -subj "/CN=oac-mcp-agent"
+  3. Register oac-cert.pem on the Confidential App as a Trusted Client
+     cert in your OCI Identity Domain.
+  4. Fill in the CONFIG block below.
+  5. python3 mint-and-exchange.py
+"""
+
+import base64
+import json
+import time
+import uuid
+from pathlib import Path
+
+import requests
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
+
+
+# ─── CONFIG — fill in these values ───────────────────────────────
+# Path to the PEM-encoded private key whose public cert is registered in IDCS.
+# Relative paths are resolved next to this script.
+PRIVATE_KEY_PATH   = "oac-jwt-key.pem"
+
+# Your OCI Identity Domain host (NOT the user-facing domain console URL).
+# Looks like: idcs-<32-hex-chars>.identity.oraclecloud.com
+IDCS_HOST          = "idcs-<your-domain-id>.identity.oraclecloud.com"
+
+# Client ID of the Confidential Application that has the cert imported as
+# a Trusted Client cert and "JWT Assertion" in Allowed grant types.
+CLIENT_ID          = "<your-confidential-app-client-id>"
+
+# OAC user the agent will operate AS. Must be Active and have access to the
+# subject areas / datasets you intend to query. All chat users will see data
+# filtered as this user — no per-user RLS in this sample.
+SERVICE_USER_EMAIL = "oac-agent-svc@your-org.com"
+
+# Full OAC scope from the Token Issuance Policy → Resources table on the
+# Confidential App. Uses the IDCS-registered hash hostname (NOT the
+# user-facing OAC URL). Format:
+#   https://<hash>.analytics.ocp.oraclecloud.comurn:opc:resource:consumer::all
+SCOPE              = "https://<hash>.analytics.ocp.oraclecloud.comurn:opc:resource:consumer::all"
+
+# OAC analytics host (the user-facing one — what you see in the OAC console).
+# Used only to print the test curl command at the end.
+OAC_HOST           = "<your-oac-tenant>.analytics.ocp.oraclecloud.com"
+
+# Cert alias you set when importing the cert in IDCS. Used as the JWT `kid`
+# header so IDCS can find the right cert to verify the signature against.
+CERT_ALIAS         = "oac-mcp"
+
+
+# ─── Mint + exchange ─────────────────────────────────────────────
+
+
+def _mint_jwt(claims: dict, key) -> str:
+    # IDCS uses `kid` to identify which registered cert to verify against.
+    header = {"alg": "RS256", "typ": "JWT", "kid": CERT_ALIAS}
+    seg = lambda d: base64.urlsafe_b64encode(
+        json.dumps(d, separators=(",", ":")).encode()
+    ).rstrip(b"=")
+    body = seg(header) + b"." + seg(claims)
+    sig = key.sign(body, padding.PKCS1v15(), hashes.SHA256())
+    return (body + b"." + base64.urlsafe_b64encode(sig).rstrip(b"=")).decode()
+
+
+def main() -> None:
+    key_path = Path(PRIVATE_KEY_PATH)
+    if not key_path.is_absolute():
+        key_path = Path(__file__).parent / key_path
+    key = load_pem_private_key(key_path.read_bytes(), password=None)
+    token_url = f"https://{IDCS_HOST}/oauth2/v1/token"
+
+    now  = int(time.time())
+    base = {
+        "iss": CLIENT_ID,
+        # OCI Identity Domains expects the generic Oracle audience here,
+        # NOT the tenant-specific token URL. Counter-intuitive but correct
+        # per Oracle docs.
+        "aud": "https://identity.oraclecloud.com/",
+        "iat": now,
+        "exp": now + 300,
+        "jti": str(uuid.uuid4()),
+    }
+    client_jwt = _mint_jwt({**base, "sub": CLIENT_ID}, key)
+    user_jwt   = _mint_jwt({**base, "sub": SERVICE_USER_EMAIL}, key)
+
+    print(f"→ POST {token_url}")
+    r = requests.post(
+        token_url,
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+            "assertion": user_jwt,
+            "client_assertion_type":
+                "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion": client_jwt,
+            "scope": SCOPE,
+        },
+        timeout=30,
+    )
+    if not r.ok:
+        print(f"✗ {r.status_code}: {r.text}")
+        raise SystemExit(1)
+
+    data = r.json()
+    access_token = data["access_token"]
+    print(f"✓ access_token (TTL={data.get('expires_in', '?')}s)")
+    print(f"  first 30: {access_token[:30]}...")
+
+    print()
+    print("Test against /api/mcp:")
+    print(f"  curl -i -X POST -H 'Authorization: Bearer {access_token[:20]}...' \\")
+    print(f"    -H 'Content-Type: application/json' \\")
+    print(f"    -H 'Accept: application/json, text/event-stream' \\")
+    print(f"    -d '{{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\",\"params\":{{}}}}' \\")
+    print(f"    https://{OAC_HOST}/api/mcp")
+    print()
+    print("Full token (paste into curl):")
+    print(access_token)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Description

Adds a code-first AIDP agent that fans out across three Oracle data sources via the Model Context Protocol, under `ai/agent-flows/code-first/multi-mcp-chat-agent/`. The agent presents a single chat surface to the user and lets the LLM decide which Oracle service to query for each question:

- **Oracle Autonomous Database (ADB)** — natural language to SQL via Select AI MCP
- **Oracle Analytics Cloud (OAC)** — Logical SQL on subject areas / datasets via OAC's `/api/mcp` endpoint
- **Oracle Integration Cloud (OIC)** — invokes OIC integrations exposed as tools by an OIC project's MCP server

Each integration can be enabled or disabled independently in `config.yaml`, so users can run the agent against any combination of these sources without modifying code.

The sample is intentionally complete enough to study and reproduce. It includes:

- `agent.py` — the AgentBasic AIDP entrypoint, with extensive inline pedagogy on the non-obvious parts (JWT minting from a long-lived private key, ExceptionGroup unwrapping for MCP TaskGroup errors, conversation healing via RemoveMessage, on-demand token freshness, and reactive recovery layered with hard-clear fallback)
- `config.sample.yaml` — fully-commented configuration template
- `enable-mcp-selectai.sql` — ADB-side SQL template that enables Resource Principal auth, creates a Select AI profile, and registers it as an MCP tool
- `mint-and-exchange.py` — local pre-flight verification script that validates the IDCS + OAC JWT exchange chain BEFORE deploying the agent (saves a lot of debug time)
- `README.md` — per-integration setup walkthrough, security notes for the OAC service-user impersonation model, and a troubleshooting table mapping symptoms to fixes

**Authentication highlights** — none of the three integrations rely on a rotating refresh chain that can break overnight:

- **ADB**: OAuth 2.0 Resource Owner Password Credentials grant (RFC 6749 §4.3) against ADB's data-access endpoint
- **OAC**: OAuth 2.0 JWT Bearer grant / User Assertion (RFC 7523), locally signed from a long-lived private key registered as a Trusted Client cert in IDCS. The agent operates as a dedicated service user — see the security note in the README about that trust model.
- **OIC**: OAuth 2.0 client_credentials (RFC 6749 §4.4), with the deployed Confidential App mapped to the OIC `ServiceInvoker` role

**Resilience design** — at the top of every `invoke()` the agent decodes the cached OAC JWT's `exp` claim and mints a fresh token if there's <60s remaining. This handles AIDP's idle-suspend behavior (OAC tokens have a 5-minute TTL, so any suspend longer than that wakes the agent up with an expired bearer). When tool calls still fail mid-flight, a reactive retry rebuilds MCP and heals orphan tool_calls; a final hard-clear-and-retry path catches the rare cases the orphan healer can't handle. All technical errors are logged for ops but the user only sees a friendly "please try again" message — never a stack trace.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

End-to-end tested against an AIDP deployment of the agent with all three integrations enabled, exercised through both the AIDP console chat and a separate browser UI proxy.

- [x] **Per-integration tool calls work**: ADB Select AI returns SQL results, OAC Logical SQL returns rows from subject areas, OIC integrations execute and return their structured output.
- [x] **JWT chain verified independently**: ran `mint-and-exchange.py` from both a laptop and from inside AIDP's notebook runner, confirming both produce a valid OAC access_token and the test curl call against `/api/mcp` returns 200 with a tools list.
- [x] **OAC token freshness across long idle**: deployed the agent, left it idle for 30 minutes, then sent an OAC question. The proactive freshness check fired (logs confirm `OAC token has Xs remaining (≤60s threshold) — refreshing`), MCP rebuilt, and the message succeeded without a user-visible failure.
- [x] **Friendly recovery messages**: simulated mid-conversation tool failures by killing the OAC bearer manually; the user sees the friendly "I ran into a problem … please try again" message instead of a stack trace, and a follow-up message succeeds after recovery.
- [x] **Independent enable/disable**: ran the agent in three configurations (ADB-only, OAC-only, OIC-only) plus the full three-way setup. The system prompt adapts to enabled integrations and all combinations work.

**Test Configuration**:
* Python: 3.11 (AIDP runtime)
* AIDP Workbench instance with the agent deployed via the AIDP agent UI
* OCI region: us-ashburn-1
* ADB version: 23ai (supports Select AI MCP)
* OAC: Enterprise Edition with `/api/mcp` endpoint enabled and a registered Trusted Client X.509 cert in the IDCS Confidential App
* OIC: 3.x project with REST-triggered integrations registered under AI Agents → Tools, Confidential App mapped to `ServiceInvoker` role on the OIC instance

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
