### PR TITLE
code examples with remote MCP server calls

### DIFF
--- a/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-no-auth.py
+++ b/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-no-auth.py
@@ -1,0 +1,177 @@
+"""
+Weather MCP – High-Code Sample (Using Allowed MCP Tools)
+
+Demonstrates:
+- Single Agent
+- Custom MCP Server
+- Allowed Tool Filtering
+- Structured Tool Building
+- NO_AUTH transport
+"""
+
+import asyncio
+import logging
+from langchain.agents import create_agent
+from langchain_core.messages import HumanMessage
+
+from aidputils.agents.toolkit.configs import OCIAIConf
+from aidputils.agents.toolkit.tool_helper import build_structured_tools_from_allowed_mcp_tools
+from aidputils.agents.toolkit.agent_helper import (
+    init_oci_llm,
+    pre_tool_setup,
+    post_tool_setup,
+    pre_invoke_setup,
+)
+
+# --------------------------------------------------
+# Logging
+# --------------------------------------------------
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("weather_mcp_high_code")
+
+
+# ==================================================
+# 1️⃣ MCP SERVER CONFIGURATION
+# ==================================================
+
+# Give a name to your MCP server and provide the URL for it, e.g. : https://api.githubcopilot.com/mcp/
+MCP_SERVER_NAME = "<MCP_SERVER_NAME>"
+MCP_ENDPOINT = "<MCP_URL>"
+
+# No auth required for this MCP server
+MCP_AUTH = {
+    "authType": "NO_AUTH"
+}
+
+# Only expose selected tools to the agent. Replace with the relevant tools for your MCP server 
+# In the example below, we expose a couple of tools from a weather forecast MCP server. Replace with your own server tools. 
+ALLOWED_MCP_TOOLS = [
+    {
+        "tool": {
+            "name": "get_weather",
+            "description": "Get current weather for a given city",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "unit": {"type": "string"}
+                },
+                "required": ["city", "unit"]
+            }
+        },
+        "instruction": "",
+        "argOverrides": {}
+    },
+    {
+        "tool": {
+            "name": "weather_forecast",
+            "description": "Get weather forecast for a city",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"}
+                },
+                "required": ["city"]
+            }
+        },
+        "instruction": "",
+        "argOverrides": {}
+    }
+]
+
+# Build MCP tools from allowed list
+TOOLS = build_structured_tools_from_allowed_mcp_tools(
+    allowed_tools=ALLOWED_MCP_TOOLS,
+    server_name=MCP_SERVER_NAME,
+    endpoint=MCP_ENDPOINT,
+    transport="streamable_http",
+    auth=MCP_AUTH,
+    headers={}
+)
+
+
+# ==================================================
+# 2️⃣ LLM CONFIGURATION
+# ==================================================
+
+guardrails_config = {
+    "name": "Default Guardrails",
+    "description": "Minimal moderation setup",
+    "policies": []
+}
+# OCI GENAI endpoint is similar to this. replace with your region: https://inference.generativeai.us-phoenix-1.oci.oraclecloud.com"
+llm_conf = OCIAIConf(
+    model_provider="generic",
+    compartment_id='<YOUR_COMPARTMENT_OCID>',
+    endpoint="<OCI_GENAI_SERVICE_INFERENCE_ENDPOINT>",
+    model_id="xai.grok-4",
+    guardrails_config=guardrails_config
+)
+
+
+# ==================================================
+# 3️⃣ AGENT IMPLEMENTATION
+# ==================================================
+
+class WeatherMcpAgent:
+
+    def __init__(self):
+        self.agent = None
+
+    def setup(self):
+        logger.info("Initializing Weather MCP Agent")
+
+        oci_llm = init_oci_llm(llm_conf)
+
+        system_prompt = """
+You are a weather assistant.
+
+Rules:
+- For current weather → call get_weather
+- For forecast → call weather_forecast
+- If user asks both → call both tools
+
+Return a clear natural-language response.
+"""
+
+        self.agent = create_agent(
+            name="weather_mcp_high_code",
+            model=oci_llm,
+            tools=TOOLS,
+            system_prompt=system_prompt,
+            debug=True
+        )
+
+        logger.info("Agent ready.")
+
+    async def invoke(self, user_query: str, **kwargs):
+        token = pre_tool_setup(**kwargs)
+        config = pre_invoke_setup(**kwargs)
+
+        try:
+            message = {"messages": [dict(HumanMessage(content=user_query))]}
+            return await self.agent.ainvoke(input=message, config=config)
+        finally:
+            post_tool_setup(token)
+
+
+# ==================================================
+# 4️⃣ RUN SAMPLE
+# ==================================================
+
+async def main():
+
+    agent = WeatherMcpAgent()
+    agent.setup()
+
+    result = await agent.invoke(
+        "What is the weather and forecast for Bangalore?"
+    )
+
+    print("\nFinal Response:\n")
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-pat.py
+++ b/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-pat.py
@@ -1,0 +1,232 @@
+"""
+TestMCP – High-Code Agent (Bearer Token Auth)
+
+Features:
+- Full JSON inputSchema definitions
+- BEARER_TOKEN auth
+- Session variable token usage
+- Streamable HTTP transport
+- Streaming + Non-streaming invoke
+"""
+
+import asyncio
+import logging
+import textwrap
+from typing import AsyncGenerator, Dict, Union
+
+from langchain.agents import create_agent
+from langchain_core.messages import BaseMessage, HumanMessage
+
+from aidputils.agents.toolkit.tool_helper import build_structured_tools_from_allowed_mcp_tools
+from aidputils.agents.toolkit.agent_helper import (
+    init_oci_llm,
+    pre_tool_setup,
+    post_tool_setup,
+    pre_invoke_setup,
+    parse_stream_response,
+)
+from aidputils.agents.toolkit.configs import OCIAIConf
+
+# --------------------------------------------------
+# Logging
+# --------------------------------------------------
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("test_mcp_high_code")
+
+
+# ==================================================
+# 1️⃣ MCP CONFIGURATION (Bearer Token)
+# ==================================================
+
+# give a name to your MCP server and provide the MCP endpoint URL, e.g. : https://api.githubcopilot.com/mcp/
+MCP_SERVER_NAME = "<YOUR_MCP_SERVER_NAME>"
+MCP_ENDPOINT = "<MCP_SERVER_URL>"
+
+# Provide the bearer token value 
+MCP_AUTH = {
+    "authType": "BEARER_TOKEN",
+    "token": "<BEARER_TOKEN>"
+}
+
+MCP_HEADERS = {}
+
+# --------------------------------------------------
+# Allowed Tools (Full JSON Schema)
+# --------------------------------------------------
+# Only expose selected tools to the agent. Replace with the relevant tools for your MCP server 
+# In the example below, we expose a couple of tools from a weather forecast MCP server. Replace with your own server tools. 
+
+ALLOWED_TOOLS = [
+    {
+        "tool": {
+            "name": "get_current_weather",
+            "description": "Get current weather for a given city with advanced options.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "unit": {"type": "string", "default": "metric"},
+                    "include_historical": {"type": "boolean", "default": False},
+                    "detailed": {"type": "boolean", "default": True},
+                    "timeout": {"type": "integer", "default": 30},
+                },
+                "required": ["city"],
+            },
+        },
+        "instruction": "",
+        "argOverrides": {},
+    },
+    {
+        "tool": {
+            "name": "get_forecast",
+            "description": "Get forecast for a given city with customizable options.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                    "days": {"type": "integer", "default": 5},
+                    "unit": {"type": "string", "default": "metric"},
+                    "include_alerts": {"type": "boolean", "default": False},
+                    "detailed": {"type": "boolean", "default": True},
+                    "hourly": {"type": "boolean", "default": False},
+                },
+                "required": ["city"],
+            },
+        },
+        "instruction": "",
+        "argOverrides": {},
+    },
+]
+
+# --------------------------------------------------
+# Build StructuredTools
+# --------------------------------------------------
+
+TOOLS = build_structured_tools_from_allowed_mcp_tools(
+    allowed_tools=ALLOWED_TOOLS,
+    server_name=MCP_SERVER_NAME,
+    endpoint=MCP_ENDPOINT,
+    transport="streamable_http",
+    auth=MCP_AUTH,
+    headers=MCP_HEADERS,
+)
+
+
+# ==================================================
+# 2️⃣ LLM CONFIGURATION
+# ==================================================
+
+# no guardrails: 
+guardrails_config = {
+    "policies": []
+}
+
+model_args = {
+    "max_tokens": "500",
+    "temperature": ".9",
+    "top_p": ".9",
+}
+
+# OCI GENAI endpoint is similar to this. replace with your region: https://inference.generativeai.us-phoenix-1.oci.oraclecloud.com"
+llm_conf = OCIAIConf(
+    model_provider="generic",
+    compartment_id='<YOUR_COMPARTMENT_OCID>',
+    endpoint="<OCI_GENAI_SERVICE_INFERENCE_ENDPOINT>",
+    model_id="xai.grok-4",
+    guardrails_config=guardrails_config
+)
+
+
+# ==================================================
+# 3️⃣ AGENT IMPLEMENTATION
+# ==================================================
+
+class TestMcpAgent:
+
+    def __init__(self):
+        self.agent = None
+
+    def setup(self):
+        logger.info("Initializing TestMcpAgent")
+
+        oci_llm = init_oci_llm(llm_conf)
+
+        system_prompt = textwrap.dedent("""
+            You're a weather agent.
+            Append 12345 to every response.
+        """).strip()
+
+        self.agent = create_agent(
+            name="test_mcp_high_code",
+            model=oci_llm,
+            tools=TOOLS,
+            system_prompt=system_prompt,
+            debug=True,
+        )
+
+        logger.info("Agent ready.")
+
+    async def invoke(
+        self,
+        user_query: str,
+        **kwargs
+    ) -> Union[Dict, AsyncGenerator[BaseMessage, None]]:
+
+        config = pre_invoke_setup(**kwargs)
+        user_message = HumanMessage(content=user_query)
+        message = {"messages": [dict(user_message)]}
+
+        is_stream = bool(kwargs.get("stream", False))
+
+        if is_stream:
+            return self._stream(message, config, kwargs)
+
+        token = pre_tool_setup(**kwargs)
+        try:
+            result = await self.agent.ainvoke(input=message, config=config)
+            return {
+                **result,
+                "messages": result.get("messages", [])[-1:],
+            }
+        finally:
+            post_tool_setup(token, kwargs=kwargs)
+
+    async def _stream(self, input_data, config, kwargs):
+
+        logger.info("Starting streaming mode")
+        token = pre_tool_setup(**kwargs)
+
+        try:
+            stream = self.agent.astream(
+                input=input_data,
+                config=config,
+                stream_mode="messages"
+            )
+
+            async for chunk in parse_stream_response(stream):
+                yield chunk
+
+        finally:
+            post_tool_setup(token, kwargs=kwargs)
+
+
+# ==================================================
+# 4️⃣ RUN SAMPLE
+# ==================================================
+
+async def main():
+
+    agent = TestMcpAgent()
+    agent.setup()
+
+    result = await agent.invoke(
+        "Get current weather for Bangalore",
+    )
+
+    print("\nFinal Response:\n")
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-pat.py
+++ b/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-pat.py
@@ -123,15 +123,16 @@ guardrails_config = {
 }
 
 model_args = {
-    "max_tokens": "500",
-    "temperature": ".9",
-    "top_p": ".9",
+    "max_tokens": 500,
+    "temperature": .9,
+    "top_p": .9,
 }
 
 # OCI GENAI endpoint is similar to this. replace with your region: https://inference.generativeai.us-phoenix-1.oci.oraclecloud.com"
 llm_conf = OCIAIConf(
     model_provider="generic",
     compartment_id='<YOUR_COMPARTMENT_OCID>',
+    model_args=model_args,
     endpoint="<OCI_GENAI_SERVICE_INFERENCE_ENDPOINT>",
     model_id="xai.grok-4",
     guardrails_config=guardrails_config
@@ -153,8 +154,7 @@ class TestMcpAgent:
         oci_llm = init_oci_llm(llm_conf)
 
         system_prompt = textwrap.dedent("""
-            You're a weather agent.
-            Append 12345 to every response.
+            ADD YOUR SYSTEM PROMPT HERE
         """).strip()
 
         self.agent = create_agent(
@@ -221,7 +221,7 @@ async def main():
     agent.setup()
 
     result = await agent.invoke(
-        "Get current weather for Bangalore",
+        "ADD YOUR QUERY HERE",
     )
 
     print("\nFinal Response:\n")

--- a/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-session-variables.py
+++ b/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-session-variables.py
@@ -1,0 +1,324 @@
+from aidputils.agents.toolkit.tool_helper import create_langgraph_tool
+from aidputils.agents.toolkit.agent_helper import (
+    init_oci_llm,
+    pre_tool_setup,
+    post_tool_setup,
+    pre_invoke_setup,
+    parse_stream_response,
+)
+from aidputils.agents.toolkit.configs import AIDPToolConf, OCIAIConf
+from langchain.agents import create_agent
+from langchain_core.messages import BaseMessage, AIMessage, HumanMessage, SystemMessage
+from typing import AsyncGenerator, Dict, Union
+import logging
+import json
+import textwrap
+
+AGENT_ID = "<YOUR_AGENT_ID>"
+logger = logging.getLogger(AGENT_ID)
+
+########## Checkpointer creation #############
+try:
+    from aidputils.agents.toolkit.memory_helper import get_checkpoint_saver
+    checkpointer = get_checkpoint_saver(AGENT_ID)
+except Exception:
+    checkpointer = globals().get("checkpointer", None)
+########## End Checkpointer creation #############
+
+
+########## Guardrails Configuration ################
+guardrails_config = {
+    "name": "Default Guardrails",
+    "description": "Minimal moderation setup",
+    "policies": []
+}
+########## End Guardrails Configuration ############
+
+########## Session Configuration ################ 
+#session_config = {
+#  "variables": {
+#    "sessionvariables.cred.mcp.test_mcp.bearer": {
+#      "name": "sessionvariables.cred.mcp.test_mcp.bearer",
+#      "isRequired": True,
+#      "shouldLog": False,
+#      "isSystem": True
+#    } 
+#  } 
+#}
+
+########## End Session Configuration ############
+########## Start Generated code for Agent Flow ################
+
+from aidputils.agents.toolkit.tool_helper import build_structured_tools_from_allowed_mcp_tools
+
+test_mcp_mcp_allowed_tools = [
+  {
+    "tool": {
+      "name": "get_current_weather",
+      "description": "Get current weather for a given city with advanced options.",
+      "inputSchema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          },
+          "unit": {
+            "default": "metric",
+            "type": "string"
+          },
+          "include_historical": {
+            "default": False,
+            "type": "boolean"
+          },
+          "detailed": {
+            "default": True,
+            "type": "boolean"
+          },
+          "timeout": {
+            "default": 30,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      }
+    },
+    "instruction": "",
+    "argOverrides": {}
+  },
+  {
+    "tool": {
+      "name": "get_forecast",
+      "description": "Get forecast for a given city with customizable options.",
+      "inputSchema": {
+        "properties": {
+          "city": {
+            "type": "string"
+          },
+          "days": {
+            "default": 5,
+            "type": "integer"
+          },
+          "unit": {
+            "default": "metric",
+            "type": "string"
+          },
+          "include_alerts": {
+            "default": False,
+            "type": "boolean"
+          },
+          "min_temp_threshold": {
+            "type": "number"
+          },
+          "max_temp_threshold": {
+            "type": "number"
+          },
+          "detailed": {
+            "default": True,
+            "type": "boolean"
+          },
+          "hourly": {
+            "default": False,
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "city"
+        ],
+        "type": "object"
+      }
+    },
+    "instruction": "",
+    "argOverrides": {}
+  }
+]
+
+test_mcp_mcp_custom_headers = {}
+
+# FIXED TOKEN PLACEHOLDER
+# The session variable cred.mcp.test_mcp.bearer was created in the Agent Studio under the Variables tab of your target agent. 
+# the token value is provided at runtime through session variables. 
+test_mcp_mcp_auth_config = {
+  "authType": "BEARER_TOKEN",
+  "token" : "{{sessionvariables.cred.mcp.test_mcp.bearer}}"
+}
+
+
+def fetch_mcp_tools_test_mcp():
+    tools = build_structured_tools_from_allowed_mcp_tools(
+        allowed_tools=test_mcp_mcp_allowed_tools,
+        server_name="<YOUR_MCP_SERVER_NAME>,
+        endpoint="<YOUR_MCP_SERVER_URL>",
+        transport="streamable_http",
+        auth=test_mcp_mcp_auth_config,
+        headers=test_mcp_mcp_custom_headers
+    )
+    if not tools:
+        return []
+    return tools
+
+
+##### Start tool List#############
+tools_agent1 = []
+tools_agent1.extend(fetch_mcp_tools_test_mcp())
+##### End tool List#############
+
+
+########## Generated code for OCI Gen AI LLM
+
+model_args = {
+  "max_tokens": 500,
+  "temperature": 0.9,
+  "top_p": 0.9
+}
+
+llm_conf = OCIAIConf(
+    model_provider="generic",
+    compartment_id='<YOUR_COMPARTMENT_OCID>',
+    model_args=model_args,
+    endpoint="<OCI_GENAI_SERVICE_INFERENCE_ENDPOINT>",
+    model_id="xai.grok-4",
+    guardrails_config=guardrails_config
+)
+
+## Agent class definition
+class TestAf:
+
+    def __init__(self) -> None:
+        self.agent = None
+
+    def setup(self) -> None:
+
+        logger.info(llm_conf)
+
+        oci_llm = init_oci_llm(llm_conf)
+
+        system_prompt = textwrap.dedent("""
+            You're a weather agent. Append 12345 to every response.
+        """).strip()
+
+        try:
+            if checkpointer:
+                self.agent = create_agent(
+                    name=AGENT_ID,
+                    model=oci_llm,
+                    tools=tools_agent1,
+                    system_prompt=system_prompt,
+                    debug=True,
+                    checkpointer=checkpointer
+                )
+            else:
+                self.agent = create_agent(
+                    name=AGENT_ID,
+                    model=oci_llm,
+                    tools=tools_agent1,
+                    system_prompt=system_prompt,
+                    debug=True
+                )
+
+        except Exception as e:
+
+            self.agent = create_agent(
+                name=AGENT_ID,
+                model=oci_llm,
+                tools=tools_agent1,
+                system_prompt=system_prompt,
+                debug=True
+            )
+
+            logger.warning(f"Checkpointer could not be initialized {e}")
+
+        logger.info(f"Setup for agent completed {self.agent}")
+
+
+    async def invoke(
+        self,
+        user_query: str,
+        **kwargs
+    ) -> Union[Dict, AsyncGenerator[BaseMessage, None]]:
+
+        config = pre_invoke_setup(**kwargs)
+
+        user_message = HumanMessage(content=user_query)
+
+        message = {
+            "messages": [dict(user_message)]
+        }
+
+        is_stream = bool(kwargs.get("stream", False))
+
+        if is_stream:
+            return self._stream_messages(
+                input=message,
+                config=config,
+                kwargs=kwargs
+            )
+
+        token = pre_tool_setup(**kwargs)
+
+        try:
+
+            agent_response = await self.agent.ainvoke(
+                input=message,
+                config=config
+            )
+
+            final_response = {
+                **agent_response,
+                "messages": agent_response.get("messages", [])[-1:]
+            }
+
+            return final_response
+
+        except Exception:
+            logger.exception("Exception while calling invoke")
+            raise
+
+        finally:
+            post_tool_setup(token, kwargs=kwargs)
+
+
+    async def _stream_messages(
+        self,
+        input,
+        config,
+        kwargs
+    ) -> AsyncGenerator[BaseMessage, None]:
+
+        """
+        Stream messages as they are generated by the agent.
+        """
+
+        logger.info("Starting _stream_messages")
+
+        token = pre_tool_setup(**kwargs)
+
+        try:
+
+            try:
+                from aidputils.agents.auth.client.generative_ai_inference_v2_client import StreamingData
+                stream = self.agent.astream(
+                    input=input,
+                    config=config,
+                    stream_mode="messages"
+                )
+
+            except ImportError:
+
+                stream = self.agent.astream(
+                    input=input,
+                    config=config
+                )
+
+            async for chunk in parse_stream_response(stream):
+                yield chunk
+
+        except Exception:
+
+            logger.exception("Streaming error")
+            raise
+
+        finally:
+
+            post_tool_setup(token, kwargs=kwargs)

--- a/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-session-variables.py
+++ b/ai/agent-flows/code-first/mcp-examples/single-agent-mcp-session-variables.py
@@ -148,7 +148,7 @@ test_mcp_mcp_auth_config = {
 def fetch_mcp_tools_test_mcp():
     tools = build_structured_tools_from_allowed_mcp_tools(
         allowed_tools=test_mcp_mcp_allowed_tools,
-        server_name="<YOUR_MCP_SERVER_NAME>,
+        server_name="<YOUR_MCP_SERVER_NAME>",
         endpoint="<YOUR_MCP_SERVER_URL>",
         transport="streamable_http",
         auth=test_mcp_mcp_auth_config,
@@ -195,7 +195,7 @@ class TestAf:
         oci_llm = init_oci_llm(llm_conf)
 
         system_prompt = textwrap.dedent("""
-            You're a weather agent. Append 12345 to every response.
+            ADD YOUR SYSTEM PROMPT HERE
         """).strip()
 
         try:


### PR DESCRIPTION
# Description

I added three notebook examples showcasing how a developer can call remote MCP servers within agent flows using the aidpUtils library: 
* one example has no auth 
* one example has bearer token 
* one example uses session variables to set bearer token at runtime. 
