### PR TITLE
Improve RAG-with-citations sample: independent models + safer Sources stripping

### DIFF
--- a/ai/agent-flows/code-first/rag-with-citations/RAGProgramaticCitations.py
+++ b/ai/agent-flows/code-first/rag-with-citations/RAGProgramaticCitations.py
@@ -55,9 +55,16 @@ region = "<oci-region>"
 catalog = "<your-catalog-name>"
 schema = "<your-schema-name>"
 knowledge_base = "<your-knowledge-base-name>"
-# Pick a model that is available in YOUR region (availability is region-specific).
+# Pick model(s) available in YOUR region (availability is region-specific).
 # See the OCI Generative AI docs for the model IDs offered in each region.
-model_id = "<oci-genai-model-id>"
+# Two models are configured independently:
+#   - rag_tool_model_id — the LLM inside RAGTool. Its generated answer is
+#     discarded (fusion_pdf_reader keeps only the retrieved chunks), so a fast,
+#     inexpensive model is a good fit here and keeps each tool call quick.
+#   - agent_model_id — the LLM the agent uses to compose the final cited answer
+#     the user sees; prefer a stronger model here for answer quality.
+rag_tool_model_id = "<oci-genai-model-id>"
+agent_model_id = "<oci-genai-model-id>"
 endpoint = f"https://inference.generativeai.{region}.oci.oraclecloud.com"
 
 MIN_CHUNK_SCORE = 0.62
@@ -99,7 +106,7 @@ rag_conf = AIDPToolConf(
         "knowledgeBase": knowledge_base,
         "top_k": 5,
         "llm": {
-            "model_id": model_id,
+            "model_id": rag_tool_model_id,
             "model_provider": "generic",
             "compartment_id": compartment_ocid,
             "endpoint": endpoint
@@ -174,7 +181,7 @@ llm_conf = OCIAIConf(
     compartment_id=compartment_ocid,
     model_args={},
     endpoint=endpoint,
-    model_id=model_id,
+    model_id=agent_model_id,
     guardrails_config={
         "name": "Default Guardrails",
         "description": "Default empty guardrails configuration",
@@ -284,13 +291,21 @@ def append_citations_block(result: dict) -> None:
     inline_cite_re = re.compile(r"\[ref=([^\]]+)\]")
 
     # Defensively strip any "Sources"/"References"/"Citations" section the model
-    # wrote on its own, so only our authoritative, scored block remains. The
-    # keyword must START a line (a real header) — anchored with re.MULTILINE — so
-    # the same words used mid-sentence in the answer are left intact.
-    body = re.sub(
-        r"^[ \t]*(?:\*\*|__)?[ \t]*(?:sources|references|citations)\b[^\n]*\n.*\Z",
-        "", target.content, flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
-    ).rstrip()
+    # wrote on its own, so only our authoritative, scored block remains. We match
+    # ONLY a real header line — either decorated (**Sources**, ## Sources) or the
+    # bare keyword followed by a colon (Sources:) — anchored to the start of a line
+    # (re.MULTILINE). A line that merely begins with the word as prose ("Sources of
+    # this data are ...") is NOT a header, so it is left intact and the inline
+    # [ref=...] citations within the answer are preserved.
+    sources_section_re = re.compile(
+        r"^[ \t]*(?:-{3,}[ \t]*\n[ \t]*)?"                 # optional '---' rule before the header
+        r"(?:"
+        r"(?:\#{1,6}[ \t]*(?:\*\*|__)?|(?:\*\*|__))[ \t]*(?:sources|references|citations)\b[^\n]*"  # decorated header (## or **)
+        r"|(?:sources|references|citations)[ \t]*:[ \t]*"                                           # bare 'Sources:' header
+        r")(?:\n.*)?\Z",                                   # then everything to the end of the answer
+        flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    )
+    body = sources_section_re.sub("", target.content).rstrip()
 
     # refs in the order the model first cites them inline.
     cited_order, seen = [], set()

--- a/ai/agent-flows/code-first/rag-with-citations/README.md
+++ b/ai/agent-flows/code-first/rag-with-citations/README.md
@@ -131,7 +131,11 @@ Both files are standalone agent flows — deploy **one** of them per agent flow.
    `<oci-region>`, `<your-catalog-name>`, `<your-schema-name>`,
    `<your-knowledge-base-name>`, and `<oci-genai-model-id>` (choose a model
    available in your region — OCI Generative AI model availability is
-   region-specific).
+   region-specific). `RAGProgramaticCitations.py` sets the model in two places:
+   `rag_tool_model_id` (RAGTool's internal synthesis, which is discarded — a
+   fast, inexpensive model works well) and `agent_model_id` (composes the final
+   cited answer — prefer a stronger model); both default to the
+   `<oci-genai-model-id>` placeholder.
 5. Set that file as the **entry file**.
 6. Attach an AI compute.
 7. Run the Python file, then test the agent from the **Test** tab of your agent


### PR DESCRIPTION
## Summary

Two improvements to the `code-first/rag-with-citations` example (`RAGProgramaticCitations.py`), plus a small README note.

### 1. Configure the RAGTool model and the agent model independently

Splits the single `model_id` into `rag_tool_model_id` and `agent_model_id`.

`fusion_pdf_reader` deliberately drops RAGTool's own synthesized answer and reasons over the retrieved chunks only — but RAGTool still runs that synthesis on every call. Separating the two model settings lets the (discarded) RAGTool synthesis use a fast, inexpensive model, while the agent — which composes the final cited answer the user actually reads — uses a stronger model. Both keep the `<oci-genai-model-id>` placeholder.

### 2. Anchor the defensive "Sources" stripping to a real header line

`append_citations_block` strips any Sources/References/Citations section the model writes on its own (it is replaced by the authoritative, scored block). The earlier pattern treated *any* line that merely began with one of those words as a header, so a sentence like "Sources of this data are validated…" — and every inline `[ref=...]` after it — could be truncated under `re.DOTALL`.

The pattern now matches only a genuine header:
- a Markdown heading or bold decoration — `## Sources`, `**Sources**`, `### **References**`
- or the bare keyword followed by a colon — `Sources:`
- optionally preceded by a `---` rule

Prose that merely starts with the word is left intact, preserving the inline citations.

### Notes
- No change to citation numbering, the scored Sources block, or `result["citations"]`.
- The README deploy step now documents the two model variables.
