### PR TITLE
Add AIDP-via-JDBC sample: Instance Principal auth via the Resource-Principal (RPST) bridge

### DIFF
--- a/data-engineering/aidp-via-jdbc/README.md
+++ b/data-engineering/aidp-via-jdbc/README.md
@@ -1,0 +1,193 @@
+# AIDP via JDBC — Instance Principal auth (via the Resource‑Principal RPST bridge)
+
+This sample connects to an **Oracle AI Data Platform (AIDP)** Spark compute
+cluster over the **Simba Spark JDBC** driver and authenticates with the host
+VM's **OCI Instance Principal** — no IAM user, no API signing key, no password.
+
+> **Which principal is actually used?** The *authentication identity* is the
+> **Instance Principal**. There is no OCI Resource Principal involved as an
+> identity (a plain compute VM does not have one). The **Resource‑Principal
+> (RPST) mechanism is reused only as the driver's transport** for the Instance
+> Principal's token. See [Instance Principal vs Resource Principal](#instance-principal-vs-resource-principal-what-is-actually-used).
+
+It is meant to run on an OCI compute instance whose instance principal is in a
+**dynamic group that is mapped to an AIDP role**. The script runs a SQL query
+(`SHOW DATABASES` by default) against a live cluster to prove connectivity.
+
+The sample artifact is:
+
+- [connect_aidp_instance_principal.py](./connect_aidp_instance_principal.py)
+
+## Why this sample exists
+
+A common pattern is to query AIDP from an automation host (CI runner, ETL VM,
+bastion) **without** distributing user credentials or API keys. OCI Instance
+Principal is the idiomatic answer: the VM proves its identity to OCI from the
+Instance Metadata Service, and AIDP authorizes it through a dynamic-group →
+role mapping.
+
+The catch: the Simba Spark JDBC driver exposes three OCI auth modes —
+**API signing key**, **browser token**, and **Resource Principal (RPST)** — but
+has **no dedicated "instance principal" mode**. This sample bridges the gap.
+
+## How the authentication works
+
+```
+  OCI compute VM (instance principal in a dynamic group mapped to an AIDP role)
+        │
+        │ 1. oci SDK: InstancePrincipalsSecurityTokenSigner()
+        │    └─ federation security token  +  ephemeral private key   (from IMDS 169.254.169.254)
+        │
+        │ 2. expose them as the Resource-Principal v2.2 contract:
+        │       OCI_RESOURCE_PRINCIPAL_VERSION=2.2
+        │       OCI_RESOURCE_PRINCIPAL_RPST=<token file>
+        │       OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM=<key file>
+        │       OCI_RESOURCE_PRINCIPAL_REGION=<region>
+        │
+        │ 3. JDBC connect with ...;OCITokenAuthType=resource_principal
+        ▼
+  AIDP JDBC gateway  ──►  Spark compute cluster   (query runs as the instance principal)
+```
+
+The driver reads the `OCI_RESOURCE_PRINCIPAL_*` variables at connect time, so
+they **must be set before the JVM starts**. The token and key are written to a
+short-lived temp directory and deleted when the script exits.
+
+> Note: the `security_token_file` (session-token) profile path is **not** a
+> working alternative here — the driver's OCI config-file reader requires a
+> `fingerprint` (it only supports the API-signing-key shape), so it rejects a
+> session-token profile. The Resource-Principal env-var path above is the one
+> that works.
+
+## Instance Principal vs Resource Principal — what is actually used
+
+This sample legitimately involves **both terms**, in two distinct roles, so it
+is worth being precise:
+
+| Concern | What is used | Detail |
+|---|---|---|
+| **Authentication identity** | **Instance Principal** | `oci.auth.signers.InstancePrincipalsSecurityTokenSigner()`. AIDP authorizes the VM through its dynamic‑group → AIDP‑role mapping. The federation token presented is the *instance's*; the resolved principal type is `instance`. |
+| **Driver transport contract** | **Resource Principal (RPST) code path** | The Simba driver has no native instance‑principal mode and accepts an externally‑supplied token *only* through its RPST path. We therefore populate `OCI_RESOURCE_PRINCIPAL_*` and set `OCITokenAuthType=resource_principal` — but the token + key written there are the **Instance Principal's**, not a real Resource Principal's. |
+
+In other words: **auth = Instance Principal; carrier = the Resource‑Principal
+RPST mechanism.** This is *not* the same as OCI Resource Principal
+authentication — `oci.auth.signers.get_resource_principals_signer()` would fail
+on a plain compute VM because no RPST tokens are issued to it. We mint the
+Instance Principal's token ourselves and hand it to the driver through the RPST
+env‑var contract.
+
+## Prerequisites
+
+### 1. IAM / AIDP authorization (one-time, by an admin)
+
+- A **dynamic group** that matches your VM, e.g. by compartment:
+  ```
+  ANY {instance.compartment.id = '<your-compartment-ocid>'}
+  ```
+  (or match a specific `instance.id`).
+- That dynamic group added as a **member of an AIDP role** (AIDP has its own
+  RBAC, separate from OCI IAM policies). When adding a dynamic group to an AIDP
+  role, the member `type` is `GROUP` (not `DYNAMIC_GROUP`).
+
+### 2. Host VM runtime
+
+| Requirement | Notes |
+|---|---|
+| Runs on an OCI compute instance | IMDS (`169.254.169.254`) must be reachable. This will **not** work off-OCI. |
+| Network access to the AIDP JDBC gateway | TCP `443` to `gateway.datalake.<region>.oci.oraclecloud.com`. |
+| **Java 8+** (tested on OpenJDK 17) | `JAVA_HOME` set, or `libjvm` is auto-discovered under `/usr/lib/jvm`. |
+| **Python 3.8+** | The script uses `jaydebeapi`, `JPype1` (needs 3.8+), `oci`, `cryptography`. |
+| **Simba Spark JDBC driver** | `SparkJDBC<version>.jar` (see below). |
+
+### 3. The Simba Spark JDBC driver
+
+Download the **Simba Apache Spark JDBC** driver (the OCI-flavored build that
+ships the `com.simba.spark.jdbc.Driver` class and supports `SparkServerType=IDL`)
+and place the jar on the host. Set its path via `--jar` or `SIMBA_JDBC_JAR`.
+The driver is also obtainable from the AIDP / Oracle Intelligent Data Lake
+connection documentation.
+
+## Setup
+
+```bash
+# 1. (recommended) a virtualenv
+python3 -m venv ~/aidp_jdbc_venv
+source ~/aidp_jdbc_venv/bin/activate
+
+# 2. Python packages
+pip install -r requirements.txt
+
+# 3. point at the driver jar
+export SIMBA_JDBC_JAR=/path/to/SparkJDBC2.6.18.2065.jar
+```
+
+## Run
+
+```bash
+python connect_aidp_instance_principal.py \
+  --region us-ashburn-1 \
+  --cluster-key <YOUR_CLUSTER_KEY> \
+  --query "SHOW DATABASES"
+```
+
+The **cluster key** is the AIDP compute cluster's id; it becomes the JDBC
+`httpPath=cliservice/<cluster-key>`. Find it in the AIDP console (cluster
+details) or via the AIDP API/SDK.
+
+### Configuration
+
+All options are settable by flag or environment variable:
+
+| Flag | Env var | Default |
+|---|---|---|
+| `--region` | `AIDP_REGION` | `us-ashburn-1` |
+| `--gateway` | `AIDP_JDBC_GATEWAY` | derived: `gateway.datalake.<region>.oci.oraclecloud.com` |
+| `--cluster-key` | `AIDP_CLUSTER_KEY` | *(required)* |
+| `--jar` | `SIMBA_JDBC_JAR` | `./SparkJDBC2.6.18.2065.jar` |
+| `--jvm` | `JVM_PATH` | auto-discovered `libjvm` |
+| `--query` | `AIDP_QUERY` | `SHOW DATABASES` |
+
+### Expected output
+
+```
+Connecting to gateway.datalake.us-ashburn-1.oci.oraclecloud.com (cluster <cluster-key>) as instance principal ...
+
+-- SHOW DATABASES --  (N row(s))
+('default',)
+('...',)
+```
+
+A `SELECT` works the same way:
+
+```bash
+python connect_aidp_instance_principal.py \
+  --cluster-key <YOUR_CLUSTER_KEY> \
+  --query "SELECT * FROM <db>.<table> LIMIT 5"
+```
+
+## Security notes
+
+- The federation token and ephemeral private key are written to a `0600`
+  temp directory and **removed on exit** (`finally`). Nothing is persisted.
+- Instance-principal tokens are **short-lived**. This sample mints a fresh one
+  per run, so it is ideal for short queries/jobs. A long-running process would
+  need to refresh the token and reconnect.
+- No secrets are stored in this repo or in the script.
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| `(500654) Error reading the following properties in the OCI Config file: fingerprint` | You tried the OCI **config-file** auth path. Use the Resource-Principal env-var path (this sample's default); the driver's config-file path is API-key only. |
+| `401`/`403` / authorization errors at connect | The instance principal is not (yet) authorized in AIDP. Confirm the VM is in the dynamic group and that the dynamic group is a member of an AIDP role. |
+| Instance Metadata Service not reachable / hang building the signer | You are not running on an OCI instance (IMDS `169.254.169.254` is unroutable off-OCI). |
+| `Could not start JVM` / libjvm not found | Install a JDK and set `JAVA_HOME`, or pass `--jvm /path/to/libjvm.so`. |
+| Connection times out | The host cannot reach `gateway.datalake.<region>.oci.oraclecloud.com:443`. Check egress / service gateway / NSGs. |
+
+## References
+
+- OCI SDK Authentication Methods —
+  https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm
+- Calling instance metadata service (IMDS) —
+  https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/gettingmetadata.htm
+- JayDeBeApi — https://pypi.org/project/JayDeBeApi/ · JPype — https://jpype.readthedocs.io/

--- a/data-engineering/aidp-via-jdbc/README.md
+++ b/data-engineering/aidp-via-jdbc/README.md
@@ -8,7 +8,7 @@ VM's **OCI Instance Principal** — no IAM user, no API signing key, no password
 > **Instance Principal**. There is no OCI Resource Principal involved as an
 > identity (a plain compute VM does not have one). The **Resource‑Principal
 > (RPST) mechanism is reused only as the driver's transport** for the Instance
-> Principal's token. See [Instance Principal vs Resource Principal](#instance-principal-vs-resource-principal-what-is-actually-used).
+> Principal's token. See [Instance Principal vs Resource Principal](#instance-principal-vs-resource-principal).
 
 It is meant to run on an OCI compute instance whose instance principal is in a
 **dynamic group that is mapped to an AIDP role**. The script runs a SQL query
@@ -59,7 +59,7 @@ short-lived temp directory and deleted when the script exits.
 > session-token profile. The Resource-Principal env-var path above is the one
 > that works.
 
-## Instance Principal vs Resource Principal — what is actually used
+## Instance Principal vs Resource Principal
 
 This sample legitimately involves **both terms**, in two distinct roles, so it
 is worth being precise:
@@ -146,6 +146,7 @@ All options are settable by flag or environment variable:
 | `--jar` | `SIMBA_JDBC_JAR` | `./SparkJDBC2.6.18.2065.jar` |
 | `--jvm` | `JVM_PATH` | auto-discovered `libjvm` |
 | `--query` | `AIDP_QUERY` | `SHOW DATABASES` |
+| `--max-rows` | `AIDP_MAX_ROWS` | `100` (output is bounded; prints `truncated` if exceeded) |
 
 ### Expected output
 
@@ -167,8 +168,9 @@ python connect_aidp_instance_principal.py \
 
 ## Security notes
 
-- The federation token and ephemeral private key are written to a `0600`
-  temp directory and **removed on exit** (`finally`). Nothing is persisted.
+- The federation token and ephemeral private key are each written to a `0600`
+  file inside a `0700` temp directory, and the directory is **removed on exit**
+  (`finally`). Nothing is persisted.
 - Instance-principal tokens are **short-lived**. This sample mints a fresh one
   per run, so it is ideal for short queries/jobs. A long-running process would
   need to refresh the token and reconnect.

--- a/data-engineering/aidp-via-jdbc/connect_aidp_instance_principal.py
+++ b/data-engineering/aidp-via-jdbc/connect_aidp_instance_principal.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Connect to Oracle AI Data Platform (AIDP) Spark compute over the Simba Spark
+JDBC driver, authenticating with the host VM's OCI **Instance Principal**
+(no IAM user, no API signing key, no password).
+
+Why this looks the way it does
+------------------------------
+The Simba Spark JDBC driver exposes three OCI auth modes: API signing key,
+browser token, and Resource Principal (RPST). It has *no* dedicated
+"instance principal" mode. We therefore bridge the instance principal into the
+driver's Resource-Principal path:
+
+  1. Mint the instance principal's federation **security token** + **ephemeral
+     private key** from the Instance Metadata Service (IMDS) using the OCI SDK.
+  2. Expose them through the ``OCI_RESOURCE_PRINCIPAL_*`` environment variables
+     (the v2.2 RPST contract the driver already understands).
+  3. Open the JDBC connection with ``OCITokenAuthType=resource_principal``.
+
+The host's instance principal must belong to a dynamic group that is mapped to
+an AIDP role (AIDP has its own RBAC, separate from OCI IAM policies).
+
+Prerequisites
+-------------
+* Java 8+ (tested on OpenJDK 17). ``JAVA_HOME`` set, or libjvm auto-discovered.
+* Simba Spark JDBC driver jar (``SparkJDBC<ver>.jar``).
+* Python 3.8+ with: ``pip install jaydebeapi JPype1 oci``.
+* Runs on an OCI compute instance whose instance principal is mapped to an
+  AIDP role, with network reachability to the AIDP JDBC gateway (TCP 443).
+
+Configuration (all overridable by environment variable or CLI flag)
+-------------------------------------------------------------------
+  AIDP_REGION         OCI region                (default: us-ashburn-1)
+  AIDP_JDBC_GATEWAY   AIDP JDBC gateway host
+  AIDP_CLUSTER_KEY    Target compute cluster key (the httpPath cliservice id)
+  SIMBA_JDBC_JAR      Absolute path to the Simba driver jar
+  JVM_PATH            Absolute path to libjvm.{so,dylib} (optional)
+  AIDP_QUERY          SQL to run                 (default: SHOW DATABASES)
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import os
+import shutil
+import sys
+import tempfile
+
+import oci
+from cryptography.hazmat.primitives import serialization
+
+DRIVER_CLASS = "com.simba.spark.jdbc.Driver"
+
+DEFAULTS = {
+    "region":   os.environ.get("AIDP_REGION", "us-ashburn-1"),
+    # Leave blank to derive from region: gateway.datalake.<region>.oci.oraclecloud.com
+    "gateway":  os.environ.get("AIDP_JDBC_GATEWAY", ""),
+    "cluster":  os.environ.get("AIDP_CLUSTER_KEY", ""),
+    "jar":      os.environ.get("SIMBA_JDBC_JAR", "./SparkJDBC2.6.18.2065.jar"),
+    "jvm":      os.environ.get("JVM_PATH", ""),
+    "query":    os.environ.get("AIDP_QUERY", "SHOW DATABASES"),
+}
+
+
+def gateway_for(region: str, override: str = "") -> str:
+    """The AIDP JDBC gateway host for a region (overridable)."""
+    return override or f"gateway.datalake.{region}.oci.oraclecloud.com"
+
+
+def mint_instance_principal_rpst(tmpdir: str) -> tuple[str, str]:
+    """Mint the instance principal's federation token + ephemeral key.
+
+    Returns paths to (token_file, key_file). The key is written PKCS#8 PEM and
+    chmod 600. Both files are short-lived; the caller deletes them.
+    """
+    signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
+    fed = signer.federation_client
+    token = fed.get_security_token()
+    private_key = fed.session_key_supplier.get_key_pair()["private"]
+    key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    token_file = os.path.join(tmpdir, "rpst_token")
+    key_file = os.path.join(tmpdir, "rpst_key.pem")
+    with open(token_file, "w") as fh:
+        fh.write(token)
+    with open(key_file, "w") as fh:
+        fh.write(key_pem)
+    os.chmod(key_file, 0o600)
+    return token_file, key_file
+
+
+def discover_libjvm(explicit: str = "") -> str:
+    """Find libjvm.{so,dylib}; fall back to JPype's default search."""
+    if explicit:
+        return explicit
+    patterns = (
+        "/usr/lib/jvm/*/lib/server/libjvm.so",
+        "/usr/lib/jvm/*/lib/*/server/libjvm.so",
+        "/Library/Java/JavaVirtualMachines/*/Contents/Home/lib/server/libjvm.dylib",
+    )
+    for pattern in patterns:
+        hits = sorted(glob.glob(pattern))
+        if hits:
+            return hits[0]
+    import jpype
+    return jpype.getDefaultJVMPath()
+
+
+def run(cfg) -> int:
+    if not cfg.cluster:
+        sys.exit("error: set AIDP_CLUSTER_KEY (or --cluster-key) to the target "
+                 "compute cluster key.")
+    if not os.path.isfile(cfg.jar):
+        sys.exit(f"error: Simba driver jar not found: {cfg.jar} "
+                 "(set SIMBA_JDBC_JAR or --jar).")
+
+    gateway = gateway_for(cfg.region, cfg.gateway)
+    jdbc_url = (
+        f"jdbc:spark://{gateway}/default;SparkServerType=IDL;"
+        f"httpPath=cliservice/{cfg.cluster};OCITokenAuthType=resource_principal"
+    )
+
+    tmpdir = tempfile.mkdtemp(prefix="aidp_ip_")
+    try:
+        token_file, key_file = mint_instance_principal_rpst(tmpdir)
+
+        # The driver reads these via System.getenv at connect time, so they
+        # MUST be set before the JVM starts.
+        os.environ["OCI_RESOURCE_PRINCIPAL_VERSION"] = "2.2"
+        os.environ["OCI_RESOURCE_PRINCIPAL_RPST"] = token_file
+        os.environ["OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM"] = key_file
+        os.environ["OCI_RESOURCE_PRINCIPAL_REGION"] = cfg.region
+
+        import jpype
+        import jaydebeapi
+
+        if not jpype.isJVMStarted():
+            jpype.startJVM(discover_libjvm(cfg.jvm),
+                           "-Djava.class.path=" + cfg.jar)
+
+        print(f"Connecting to {gateway} (cluster {cfg.cluster}) "
+              f"as instance principal ...")
+        conn = jaydebeapi.connect(DRIVER_CLASS, jdbc_url, {"ssl": "1"})
+        try:
+            cur = conn.cursor()
+            cur.execute(cfg.query)
+            rows = cur.fetchall()
+            print(f"\n-- {cfg.query} --  ({len(rows)} row(s))")
+            for row in rows:
+                print(row)
+            cur.close()
+        finally:
+            conn.close()
+        return 0
+    finally:
+        # Always remove the short-lived credential material.
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--region", default=DEFAULTS["region"])
+    p.add_argument("--gateway", default=DEFAULTS["gateway"])
+    p.add_argument("--cluster-key", dest="cluster", default=DEFAULTS["cluster"],
+                   help="Target compute cluster key (httpPath cliservice id).")
+    p.add_argument("--jar", default=DEFAULTS["jar"],
+                   help="Path to the Simba Spark JDBC driver jar.")
+    p.add_argument("--jvm", default=DEFAULTS["jvm"],
+                   help="Path to libjvm.so/.dylib (optional; auto-discovered).")
+    p.add_argument("--query", default=DEFAULTS["query"], help="SQL to execute.")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    sys.exit(run(parse_args()))

--- a/data-engineering/aidp-via-jdbc/connect_aidp_instance_principal.py
+++ b/data-engineering/aidp-via-jdbc/connect_aidp_instance_principal.py
@@ -36,6 +36,7 @@ Configuration (all overridable by environment variable or CLI flag)
   SIMBA_JDBC_JAR      Absolute path to the Simba driver jar
   JVM_PATH            Absolute path to libjvm.{so,dylib} (optional)
   AIDP_QUERY          SQL to run                 (default: SHOW DATABASES)
+  AIDP_MAX_ROWS       Max rows to fetch/print    (default: 100)
 """
 from __future__ import annotations
 
@@ -59,6 +60,7 @@ DEFAULTS = {
     "jar":      os.environ.get("SIMBA_JDBC_JAR", "./SparkJDBC2.6.18.2065.jar"),
     "jvm":      os.environ.get("JVM_PATH", ""),
     "query":    os.environ.get("AIDP_QUERY", "SHOW DATABASES"),
+    "max_rows": int(os.environ.get("AIDP_MAX_ROWS", "100")),
 }
 
 
@@ -67,11 +69,24 @@ def gateway_for(region: str, override: str = "") -> str:
     return override or f"gateway.datalake.{region}.oci.oraclecloud.com"
 
 
+def _write_secret(path: str, text: str) -> None:
+    """Write text to a freshly created 0600 file (created restricted, never
+    world-readable even briefly)."""
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(text)
+
+
 def mint_instance_principal_rpst(tmpdir: str) -> tuple[str, str]:
     """Mint the instance principal's federation token + ephemeral key.
 
-    Returns paths to (token_file, key_file). The key is written PKCS#8 PEM and
-    chmod 600. Both files are short-lived; the caller deletes them.
+    Returns paths to (token_file, key_file), both written 0600. The token is a
+    bearer credential and the key is the matching session key, so both are
+    treated as secrets; the caller deletes them.
+
+    Note: ``federation_client`` / ``session_key_supplier`` are OCI SDK members
+    used to surface the live token + key for the driver's RPST contract. Pin the
+    ``oci`` version if you depend on this in production.
     """
     signer = oci.auth.signers.InstancePrincipalsSecurityTokenSigner()
     fed = signer.federation_client
@@ -85,11 +100,8 @@ def mint_instance_principal_rpst(tmpdir: str) -> tuple[str, str]:
 
     token_file = os.path.join(tmpdir, "rpst_token")
     key_file = os.path.join(tmpdir, "rpst_key.pem")
-    with open(token_file, "w") as fh:
-        fh.write(token)
-    with open(key_file, "w") as fh:
-        fh.write(key_pem)
-    os.chmod(key_file, 0o600)
+    _write_secret(token_file, token)
+    _write_secret(key_file, key_pem)
     return token_file, key_file
 
 
@@ -118,6 +130,20 @@ def run(cfg) -> int:
         sys.exit(f"error: Simba driver jar not found: {cfg.jar} "
                  "(set SIMBA_JDBC_JAR or --jar).")
 
+    import jpype
+    import jaydebeapi
+
+    # The Simba jar (classpath) and the OCI_RESOURCE_PRINCIPAL_* env vars are
+    # both fixed at JVM startup, so this script must start the JVM itself. If one
+    # is already running we cannot guarantee either — fail clearly rather than
+    # silently connecting without the driver/credentials in place.
+    if jpype.isJVMStarted():
+        raise RuntimeError(
+            "A JVM is already running. Run this as a standalone process so the "
+            "Simba jar is on the classpath and OCI_RESOURCE_PRINCIPAL_* are set "
+            "before JVM initialization."
+        )
+
     gateway = gateway_for(cfg.region, cfg.gateway)
     jdbc_url = (
         f"jdbc:spark://{gateway}/default;SparkServerType=IDL;"
@@ -125,39 +151,61 @@ def run(cfg) -> int:
     )
 
     tmpdir = tempfile.mkdtemp(prefix="aidp_ip_")
+    saved_env: dict[str, str | None] = {}
     try:
         token_file, key_file = mint_instance_principal_rpst(tmpdir)
 
-        # The driver reads these via System.getenv at connect time, so they
-        # MUST be set before the JVM starts.
-        os.environ["OCI_RESOURCE_PRINCIPAL_VERSION"] = "2.2"
-        os.environ["OCI_RESOURCE_PRINCIPAL_RPST"] = token_file
-        os.environ["OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM"] = key_file
-        os.environ["OCI_RESOURCE_PRINCIPAL_REGION"] = cfg.region
+        # Set the RPST env vars (the driver reads them via System.getenv at
+        # connect time). Remember prior values so we can restore them later.
+        rp_env = {
+            "OCI_RESOURCE_PRINCIPAL_VERSION": "2.2",
+            "OCI_RESOURCE_PRINCIPAL_RPST": token_file,
+            "OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM": key_file,
+            "OCI_RESOURCE_PRINCIPAL_REGION": cfg.region,
+        }
+        for key, value in rp_env.items():
+            saved_env[key] = os.environ.get(key)
+            os.environ[key] = value
 
-        import jpype
-        import jaydebeapi
-
-        if not jpype.isJVMStarted():
+        try:
             jpype.startJVM(discover_libjvm(cfg.jvm),
                            "-Djava.class.path=" + cfg.jar)
+            print(f"Connecting to {gateway} (cluster {cfg.cluster}) "
+                  f"as instance principal ...")
+            conn = jaydebeapi.connect(DRIVER_CLASS, jdbc_url, {"ssl": "1"})
+        except Exception:
+            sys.stderr.write(
+                "\nJVM startup or JDBC connect failed. See the README "
+                "'Troubleshooting' section — common causes: JDK/libjvm not found, "
+                "the instance principal is not authorized in AIDP (dynamic group "
+                "-> role), or no network route to the gateway.\n"
+            )
+            raise
 
-        print(f"Connecting to {gateway} (cluster {cfg.cluster}) "
-              f"as instance principal ...")
-        conn = jaydebeapi.connect(DRIVER_CLASS, jdbc_url, {"ssl": "1"})
         try:
             cur = conn.cursor()
             cur.execute(cfg.query)
-            rows = cur.fetchall()
-            print(f"\n-- {cfg.query} --  ({len(rows)} row(s))")
+            # Bound the result so an arbitrary --query can't exhaust memory.
+            rows = cur.fetchmany(cfg.max_rows + 1)
+            truncated = len(rows) > cfg.max_rows
+            rows = rows[:cfg.max_rows]
+            suffix = ", truncated" if truncated else ""
+            print(f"\n-- {cfg.query} --  ({len(rows)} row(s){suffix})")
             for row in rows:
                 print(row)
+            if truncated:
+                print(f"... output truncated at --max-rows={cfg.max_rows}")
             cur.close()
         finally:
             conn.close()
         return 0
     finally:
-        # Always remove the short-lived credential material.
+        # Restore env vars and remove the short-lived credential material.
+        for key, old in saved_env.items():
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
@@ -173,6 +221,9 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--jvm", default=DEFAULTS["jvm"],
                    help="Path to libjvm.so/.dylib (optional; auto-discovered).")
     p.add_argument("--query", default=DEFAULTS["query"], help="SQL to execute.")
+    p.add_argument("--max-rows", dest="max_rows", type=int,
+                   default=DEFAULTS["max_rows"],
+                   help="Max rows to fetch/print (default 100).")
     return p.parse_args()
 
 

--- a/data-engineering/aidp-via-jdbc/requirements.txt
+++ b/data-engineering/aidp-via-jdbc/requirements.txt
@@ -1,0 +1,5 @@
+# Python packages for AIDP Instance-Principal JDBC connectivity
+oci>=2.120.0          # OCI SDK — mints the instance-principal federation token + ephemeral key
+JPype1>=1.7.0         # JVM bridge used by JayDeBeApi (requires Python 3.8+)
+JayDeBeApi>=1.2.3     # DB-API 2.0 wrapper around the JDBC driver
+cryptography>=3.4     # serialize the ephemeral session key to PEM (also an oci dependency)


### PR DESCRIPTION
## Summary

Adds `data-engineering/aidp-via-jdbc/` — a Python sample that connects to an Oracle AI Data Platform (AIDP / IDL) Spark compute cluster over the **Simba Spark JDBC** driver using the host VM's **OCI Instance Principal** (no IAM user, no API signing key, no password).

## Which principal is used — Instance Principal vs Resource Principal

Both terms appear, in **distinct roles** (called out explicitly in the README):

| Concern | What is used | Detail |
|---|---|---|
| **Authentication identity** | **Instance Principal** | `oci.auth.signers.InstancePrincipalsSecurityTokenSigner()`; AIDP authorizes the VM via its dynamic-group → AIDP-role mapping (resolved principal type is `instance`). |
| **Driver transport contract** | **Resource-Principal (RPST) code path** | The Simba driver has no native instance-principal mode, so the Instance Principal's federation token + ephemeral private key are carried through `OCI_RESOURCE_PRINCIPAL_*` + `OCITokenAuthType=resource_principal`. |

This is **not** OCI Resource Principal authentication: a plain compute VM has no RPST issued to it (`get_resource_principals_signer()` would fail). The sample mints the Instance Principal's token itself and hands it to the driver through the RPST env-var contract. The `security_token_file` (session-token) config-profile path does not work here — the driver's OCI config-file reader requires a `fingerprint` (API-signing-key shape only).

## Contents
- `connect_aidp_instance_principal.py` — env/flag-driven; mints the instance-principal credentials, sets the RPST env vars before the JVM starts, runs a query, and removes the short-lived credential files on exit.
- `README.md` — prerequisites (Java 8+/tested on 17, Simba Spark JDBC driver, Python ≥3.8 packages), IAM dynamic-group → AIDP-role setup, configuration, expected output, and troubleshooting.
- `requirements.txt`.

## Testing
Verified live on an OCI compute instance against an ACTIVE AIDP cluster: `SHOW DATABASES` and a real `SELECT` both returned rows, authenticating solely with the host instance principal (no `~/.oci` API key, no user credentials).
