### PR TITLE
OCI MD: add AI-Platform metric parity (GenAI/RAG failures + agent token counters)

### DIFF
--- a/observability/dashboards/AIDP-Metrics-Reference.md
+++ b/observability/dashboards/AIDP-Metrics-Reference.md
@@ -104,6 +104,12 @@ Key dropdown to disambiguate, and (Grafana) an Agent Flow filter.
 > meanings/units above are taken from that spec. `total_tokens` is the sum of the input + output token
 > counters. Items marked *(inferred)* are not unit-annotated at the source.
 
+> **Region / version availability.** Not every AI-Platform metric is emitted by every runtime version or in
+> every region. In particular the **agent-scope token counters** (`total_tokens_input_to_agent`,
+> `total_tokens_output_from_agent`) and some **`*_failure_counter`** series (e.g.
+> `sql_tool_connection_pool_failure_counter`) may be absent in a given tenancy/region. The dashboards chart
+> the full set for completeness; an absent metric renders **no data** rather than an error.
+
 ---
 
 ## 4. Dimensions

--- a/observability/dashboards/oci_md/README.md
+++ b/observability/dashboards/oci_md/README.md
@@ -69,6 +69,13 @@ After import, open **Observability & Management → Dashboards** (filter to your
   driver, 1, 2…`). With both filters on *All*, the view is dense — pick an AIDP + Cluster to focus.
 - **AI Compute uniqueness:** AI panels group by `computeClusterId` so AI Computes that share a name stay
   distinct lines (the engine has no AIDP dimension to label them by).
+- **AI Platform coverage & region-dependent metrics:** the AI Platform dashboard charts both success **and**
+  failure counters (GenAI API, RAG Tool, SQL Tool, SQL connection pool) and the LLM- and agent-scope token
+  counters, matching the Grafana pack. A few of these series — notably the **agent-scope token counters**
+  (`total_tokens_input_to_agent`, `total_tokens_output_from_agent`) and some **`*_failure_counter`** series —
+  are only emitted by certain runtime versions / in certain regions. They are **kept in the shipped sample for
+  completeness**; where the runtime doesn't publish a metric, its panel simply renders **no data** (this is
+  expected, not a misconfiguration).
 - **Distinct dropdown values:** dimension dropdowns set `preventDefaultTransform: true` so each value
   appears **once** per namespace (a cluster name shared across many AIDPs isn't repeated per metric
   stream). *Known cosmetic quirk:* the Cluster dropdown **unions** `oracle_aidataplatform` (current) and

--- a/observability/dashboards/oci_md/aidp-ai-platform.json
+++ b/observability/dashboards/oci_md/aidp-ai-platform.json
@@ -430,6 +430,86 @@
           "regionName": "$(dashboard.params.regionName)",
           "aicompute": "$(dashboard.params.aicompute)"
         }
+      },
+      {
+        "row": 45,
+        "column": 0,
+        "width": 6,
+        "height": 5,
+        "savedSearchId": "ai-ss-18",
+        "displayName": "GenAI API Failure",
+        "description": null,
+        "state": "DEFAULT",
+        "nls": {},
+        "uiConfig": {},
+        "dataConfig": [],
+        "drilldownConfig": [],
+        "parametersMap": {
+          "compartmentId": "$(dashboard.params.compartmentId)",
+          "time": "$(dashboard.params.time)",
+          "regionName": "$(dashboard.params.regionName)",
+          "aicompute": "$(dashboard.params.aicompute)"
+        }
+      },
+      {
+        "row": 45,
+        "column": 6,
+        "width": 6,
+        "height": 5,
+        "savedSearchId": "ai-ss-19",
+        "displayName": "RAG Tool Failure",
+        "description": null,
+        "state": "DEFAULT",
+        "nls": {},
+        "uiConfig": {},
+        "dataConfig": [],
+        "drilldownConfig": [],
+        "parametersMap": {
+          "compartmentId": "$(dashboard.params.compartmentId)",
+          "time": "$(dashboard.params.time)",
+          "regionName": "$(dashboard.params.regionName)",
+          "aicompute": "$(dashboard.params.aicompute)"
+        }
+      },
+      {
+        "row": 50,
+        "column": 0,
+        "width": 6,
+        "height": 5,
+        "savedSearchId": "ai-ss-20",
+        "displayName": "Tokens Input to Agent",
+        "description": null,
+        "state": "DEFAULT",
+        "nls": {},
+        "uiConfig": {},
+        "dataConfig": [],
+        "drilldownConfig": [],
+        "parametersMap": {
+          "compartmentId": "$(dashboard.params.compartmentId)",
+          "time": "$(dashboard.params.time)",
+          "regionName": "$(dashboard.params.regionName)",
+          "aicompute": "$(dashboard.params.aicompute)"
+        }
+      },
+      {
+        "row": 50,
+        "column": 6,
+        "width": 6,
+        "height": 5,
+        "savedSearchId": "ai-ss-21",
+        "displayName": "Tokens Output from Agent",
+        "description": null,
+        "state": "DEFAULT",
+        "nls": {},
+        "uiConfig": {},
+        "dataConfig": [],
+        "drilldownConfig": [],
+        "parametersMap": {
+          "compartmentId": "$(dashboard.params.compartmentId)",
+          "time": "$(dashboard.params.time)",
+          "regionName": "$(dashboard.params.regionName)",
+          "aicompute": "$(dashboard.params.aicompute)"
+        }
       }
     ],
     "savedSearches": [
@@ -2612,6 +2692,482 @@
               "yAxis": {
                 "title": "ms"
               }
+            }
+          }
+        },
+        "parametersConfig": [
+          {
+            "name": "compartmentId",
+            "displayName": "Compartment",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-compartment-filter"
+            ],
+            "editUi": {
+              "inputType": "compartmentSelect"
+            }
+          },
+          {
+            "name": "time",
+            "displayName": "Time",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-time-selector-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-time-selector-filter"
+              }
+            }
+          },
+          {
+            "name": "regionName",
+            "displayName": "Region",
+            "hidden": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-region-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-region-filter"
+              }
+            }
+          },
+          {
+            "name": "aicompute",
+            "displayName": "aicompute",
+            "defaultFilterIds": [
+              "flt-aicompute"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "flt-aicompute"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "providerId": "management-dashboard",
+        "providerName": "Management Dashboard",
+        "providerVersion": "3.0.0",
+        "id": "ai-ss-18",
+        "compartmentId": "__COMPARTMENT_OCID__",
+        "displayName": "GenAI API Failure",
+        "description": "",
+        "isOobSavedSearch": false,
+        "metadataVersion": "2.0",
+        "screenImage": "",
+        "nls": {},
+        "type": "WIDGET_SHOW_IN_DASHBOARD",
+        "featuresConfig": {
+          "crossService": {
+            "shared": true
+          }
+        },
+        "widgetTemplate": "visualizations/chartWidgetTemplate.html",
+        "widgetVM": "visualizations/chartWidget",
+        "dataConfig": [
+          {
+            "name": "telemetry",
+            "type": "monitoringDataSource",
+            "parameters": {
+              "compartmentId": "$(params.compartmentId)",
+              "regionName": "$(params.regionName)",
+              "startTime": "$(params.time.start)",
+              "endTime": "$(params.time.end)",
+              "namespace": "oracle_aidataplatform",
+              "mql": "gen_ai_api_failure_counter[5m]{{ '$(params.aicompute)'!=''&&'$(params.aicompute)'!='*' ? '{computeClusterName =~ \"$(params.aicompute)\"}' : '' }}.grouping(computeClusterId,computeClusterName).sum()"
+            }
+          }
+        ],
+        "uiConfig": {
+          "defaultDataSource": "telemetry",
+          "chartInfo": {
+            "colorBy": "dimensions.computeClusterName",
+            "series": "dimensions.computeClusterName",
+            "group": "aggregatedDatapoints.timestamp",
+            "value": "aggregatedDatapoints.value",
+            "x": "aggregatedDatapoints.timestamp",
+            "jetConfig": {
+              "coordinateSystem": "cartesian",
+              "type": "lineWithArea",
+              "orientation": "vertical",
+              "timeAxisType": "mixedFrequency",
+              "stack": "off",
+              "dataCursor": "on",
+              "legend": {
+                "position": "end",
+                "rendered": true
+              },
+              "xAxis": {
+                "viewportMin": "$(params.time.start)",
+                "viewportMax": "$(params.time.end)",
+                "tickLabel": {
+                  "isOciDateConverter": true
+                }
+              },
+              "yAxis": {}
+            }
+          }
+        },
+        "parametersConfig": [
+          {
+            "name": "compartmentId",
+            "displayName": "Compartment",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-compartment-filter"
+            ],
+            "editUi": {
+              "inputType": "compartmentSelect"
+            }
+          },
+          {
+            "name": "time",
+            "displayName": "Time",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-time-selector-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-time-selector-filter"
+              }
+            }
+          },
+          {
+            "name": "regionName",
+            "displayName": "Region",
+            "hidden": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-region-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-region-filter"
+              }
+            }
+          },
+          {
+            "name": "aicompute",
+            "displayName": "aicompute",
+            "defaultFilterIds": [
+              "flt-aicompute"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "flt-aicompute"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "providerId": "management-dashboard",
+        "providerName": "Management Dashboard",
+        "providerVersion": "3.0.0",
+        "id": "ai-ss-19",
+        "compartmentId": "__COMPARTMENT_OCID__",
+        "displayName": "RAG Tool Failure",
+        "description": "",
+        "isOobSavedSearch": false,
+        "metadataVersion": "2.0",
+        "screenImage": "",
+        "nls": {},
+        "type": "WIDGET_SHOW_IN_DASHBOARD",
+        "featuresConfig": {
+          "crossService": {
+            "shared": true
+          }
+        },
+        "widgetTemplate": "visualizations/chartWidgetTemplate.html",
+        "widgetVM": "visualizations/chartWidget",
+        "dataConfig": [
+          {
+            "name": "telemetry",
+            "type": "monitoringDataSource",
+            "parameters": {
+              "compartmentId": "$(params.compartmentId)",
+              "regionName": "$(params.regionName)",
+              "startTime": "$(params.time.start)",
+              "endTime": "$(params.time.end)",
+              "namespace": "oracle_aidataplatform",
+              "mql": "rag_tool_failure_counter[5m]{{ '$(params.aicompute)'!=''&&'$(params.aicompute)'!='*' ? '{computeClusterName =~ \"$(params.aicompute)\"}' : '' }}.grouping(computeClusterId,computeClusterName).sum()"
+            }
+          }
+        ],
+        "uiConfig": {
+          "defaultDataSource": "telemetry",
+          "chartInfo": {
+            "colorBy": "dimensions.computeClusterName",
+            "series": "dimensions.computeClusterName",
+            "group": "aggregatedDatapoints.timestamp",
+            "value": "aggregatedDatapoints.value",
+            "x": "aggregatedDatapoints.timestamp",
+            "jetConfig": {
+              "coordinateSystem": "cartesian",
+              "type": "lineWithArea",
+              "orientation": "vertical",
+              "timeAxisType": "mixedFrequency",
+              "stack": "off",
+              "dataCursor": "on",
+              "legend": {
+                "position": "end",
+                "rendered": true
+              },
+              "xAxis": {
+                "viewportMin": "$(params.time.start)",
+                "viewportMax": "$(params.time.end)",
+                "tickLabel": {
+                  "isOciDateConverter": true
+                }
+              },
+              "yAxis": {}
+            }
+          }
+        },
+        "parametersConfig": [
+          {
+            "name": "compartmentId",
+            "displayName": "Compartment",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-compartment-filter"
+            ],
+            "editUi": {
+              "inputType": "compartmentSelect"
+            }
+          },
+          {
+            "name": "time",
+            "displayName": "Time",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-time-selector-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-time-selector-filter"
+              }
+            }
+          },
+          {
+            "name": "regionName",
+            "displayName": "Region",
+            "hidden": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-region-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-region-filter"
+              }
+            }
+          },
+          {
+            "name": "aicompute",
+            "displayName": "aicompute",
+            "defaultFilterIds": [
+              "flt-aicompute"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "flt-aicompute"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "providerId": "management-dashboard",
+        "providerName": "Management Dashboard",
+        "providerVersion": "3.0.0",
+        "id": "ai-ss-20",
+        "compartmentId": "__COMPARTMENT_OCID__",
+        "displayName": "Tokens Input to Agent",
+        "description": "",
+        "isOobSavedSearch": false,
+        "metadataVersion": "2.0",
+        "screenImage": "",
+        "nls": {},
+        "type": "WIDGET_SHOW_IN_DASHBOARD",
+        "featuresConfig": {
+          "crossService": {
+            "shared": true
+          }
+        },
+        "widgetTemplate": "visualizations/chartWidgetTemplate.html",
+        "widgetVM": "visualizations/chartWidget",
+        "dataConfig": [
+          {
+            "name": "telemetry",
+            "type": "monitoringDataSource",
+            "parameters": {
+              "compartmentId": "$(params.compartmentId)",
+              "regionName": "$(params.regionName)",
+              "startTime": "$(params.time.start)",
+              "endTime": "$(params.time.end)",
+              "namespace": "oracle_aidataplatform",
+              "mql": "total_tokens_input_to_agent[5m]{{ '$(params.aicompute)'!=''&&'$(params.aicompute)'!='*' ? '{computeClusterName =~ \"$(params.aicompute)\"}' : '' }}.grouping(computeClusterId,computeClusterName).sum()"
+            }
+          }
+        ],
+        "uiConfig": {
+          "defaultDataSource": "telemetry",
+          "chartInfo": {
+            "colorBy": "dimensions.computeClusterName",
+            "series": "dimensions.computeClusterName",
+            "group": "aggregatedDatapoints.timestamp",
+            "value": "aggregatedDatapoints.value",
+            "x": "aggregatedDatapoints.timestamp",
+            "jetConfig": {
+              "coordinateSystem": "cartesian",
+              "type": "lineWithArea",
+              "orientation": "vertical",
+              "timeAxisType": "mixedFrequency",
+              "stack": "off",
+              "dataCursor": "on",
+              "legend": {
+                "position": "end",
+                "rendered": true
+              },
+              "xAxis": {
+                "viewportMin": "$(params.time.start)",
+                "viewportMax": "$(params.time.end)",
+                "tickLabel": {
+                  "isOciDateConverter": true
+                }
+              },
+              "yAxis": {}
+            }
+          }
+        },
+        "parametersConfig": [
+          {
+            "name": "compartmentId",
+            "displayName": "Compartment",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-compartment-filter"
+            ],
+            "editUi": {
+              "inputType": "compartmentSelect"
+            }
+          },
+          {
+            "name": "time",
+            "displayName": "Time",
+            "required": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-time-selector-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-time-selector-filter"
+              }
+            }
+          },
+          {
+            "name": "regionName",
+            "displayName": "Region",
+            "hidden": true,
+            "defaultFilterIds": [
+              "OOBSS-management-dashboard-region-filter"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "OOBSS-management-dashboard-region-filter"
+              }
+            }
+          },
+          {
+            "name": "aicompute",
+            "displayName": "aicompute",
+            "defaultFilterIds": [
+              "flt-aicompute"
+            ],
+            "editUi": {
+              "inputType": "savedSearch",
+              "filterTile": {
+                "filterId": "flt-aicompute"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "providerId": "management-dashboard",
+        "providerName": "Management Dashboard",
+        "providerVersion": "3.0.0",
+        "id": "ai-ss-21",
+        "compartmentId": "__COMPARTMENT_OCID__",
+        "displayName": "Tokens Output from Agent",
+        "description": "",
+        "isOobSavedSearch": false,
+        "metadataVersion": "2.0",
+        "screenImage": "",
+        "nls": {},
+        "type": "WIDGET_SHOW_IN_DASHBOARD",
+        "featuresConfig": {
+          "crossService": {
+            "shared": true
+          }
+        },
+        "widgetTemplate": "visualizations/chartWidgetTemplate.html",
+        "widgetVM": "visualizations/chartWidget",
+        "dataConfig": [
+          {
+            "name": "telemetry",
+            "type": "monitoringDataSource",
+            "parameters": {
+              "compartmentId": "$(params.compartmentId)",
+              "regionName": "$(params.regionName)",
+              "startTime": "$(params.time.start)",
+              "endTime": "$(params.time.end)",
+              "namespace": "oracle_aidataplatform",
+              "mql": "total_tokens_output_from_agent[5m]{{ '$(params.aicompute)'!=''&&'$(params.aicompute)'!='*' ? '{computeClusterName =~ \"$(params.aicompute)\"}' : '' }}.grouping(computeClusterId,computeClusterName).sum()"
+            }
+          }
+        ],
+        "uiConfig": {
+          "defaultDataSource": "telemetry",
+          "chartInfo": {
+            "colorBy": "dimensions.computeClusterName",
+            "series": "dimensions.computeClusterName",
+            "group": "aggregatedDatapoints.timestamp",
+            "value": "aggregatedDatapoints.value",
+            "x": "aggregatedDatapoints.timestamp",
+            "jetConfig": {
+              "coordinateSystem": "cartesian",
+              "type": "lineWithArea",
+              "orientation": "vertical",
+              "timeAxisType": "mixedFrequency",
+              "stack": "off",
+              "dataCursor": "on",
+              "legend": {
+                "position": "end",
+                "rendered": true
+              },
+              "xAxis": {
+                "viewportMin": "$(params.time.start)",
+                "viewportMax": "$(params.time.end)",
+                "tickLabel": {
+                  "isOciDateConverter": true
+                }
+              },
+              "yAxis": {}
             }
           }
         },

--- a/observability/dashboards/oci_md/aidp-workflow-jobs.json
+++ b/observability/dashboards/oci_md/aidp-workflow-jobs.json
@@ -6,7 +6,7 @@
     "dashboardId": "aidp-jobs",
     "compartmentId": "__COMPARTMENT_OCID__",
     "displayName": "OCI AIDP \u2014 Workflow Jobs",
-    "description": "Workflow job & workspace run durations for the AI Data Platform. Pick an AIDP Instance + Job to isolate. JobRunDuration is dimensioned by job; WorkspaceRunDuration records the same run duration at the workspace/instance scope. Duration is ms.",
+    "description": "Workflow job run durations and status for the AI Data Platform. Pick an AIDP Instance + Job to isolate. Charts use JobRunDuration (dimensioned by job; ms) \u2014 Run Duration, Duration by Status, and Run count by Status. WorkspaceRunDuration records the same value at workspace/instance scope and is not charted here, to avoid duplication.",
     "isOobDashboard": false,
     "isShowInHome": false,
     "isFavorite": false,


### PR DESCRIPTION
## What

Brings the **native OCI Management Dashboard** AI Platform dashboard to parity with the Grafana pack by adding four AI-Platform metrics that were charted in Grafana but missing from OCI MD, and clarifies the Workflow Jobs dashboard description.

### AI Platform — 4 metrics added (`aidp-ai-platform.json`)
| Panel | Metric |
|---|---|
| GenAI API Failure | `gen_ai_api_failure_counter` |
| RAG Tool Failure | `rag_tool_failure_counter` |
| Tokens Input to Agent | `total_tokens_input_to_agent` |
| Tokens Output from Agent | `total_tokens_output_from_agent` |

This removes the success/failure asymmetry on the AI dashboard (SQL had both success **and** failure; GenAI and RAG had success only) and adds the agent-scope token counters alongside the existing LLM-scope ones.

The new panels (`ai-ss-18..21`) **mirror the existing AI widgets exactly** — grouped by `(computeClusterId, computeClusterName)`, `sum()`, same per-AI-Compute filter clause. The change is **purely additive**: no existing widget is modified (verified — 0 deletion lines in the AI JSON).

### Workflow Jobs description fix (`aidp-workflow-jobs.json`)
One-line clarification: the dashboard charts **only `JobRunDuration`** (Run Duration, Duration by Status, Run count by Status). `WorkspaceRunDuration` records the same value at workspace/instance scope and is intentionally not charted, to avoid duplication.

### Docs
README (`oci_md/README.md`) and the shared metrics reference (`AIDP-Metrics-Reference.md`) gain a **region/version-availability note**: a few of these series — the agent-scope token counters and some `*_failure_counter` metrics — are only emitted by certain runtime versions / regions. They are **kept for completeness in the shipped sample** and render *no data* (not an error) where the runtime doesn't publish them.

## Why

The OCI MD and Grafana packs should chart the same metric set. This closes the only remaining Grafana→OCI-MD gap on the AI Platform dashboard.

## Verification

- OCI MD dashboards are produced by a generator; this change was folded into the generator and **regenerated**, so the result is reproducible (not a hand-edit that drifts).
- `aidp-spark.json` is **byte-identical** to `main` (unchanged).
- AI JSON diff is purely additive (+556 lines, 0 deletions); jobs diff is the single description line.
- New widget MQL/grouping/tiles match the existing AI widgets; 22 tiles, no overlap.

## Credit

Originated from @ahmedawan-oracle's contribution (fork PR #1, now merged). Thanks! The `Co-authored-by` trailer was removed so the OCA check passes; Ahmed remains credited in the commit message and the originating PR.