### PR TITLE
engineer-agent: remove competitor + internal-product references from docs

### DIFF
--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/CHANGELOG.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/CHANGELOG.md
@@ -36,8 +36,7 @@ All notable changes to this plugin are documented here. Format loosely follows
 
 Public-directory polish ahead of submission to the official plugin directory (docs/metadata only; no skill change):
 - Rewrote the `plugin.json` / `marketplace.json` `description` and the README hero into tighter, wow-factor copy
-  led by "Run your entire AI data platform in English" + a "Why this vs a pipeline orchestrator" comparison
-  table (honest — Airflow / dbt / data lineage / 2→3-migration credited to Astronomer).
+  led by "Run your entire AI data platform in English".
 - **Removed the `author` field** from `plugin.json` so no personal "Made by" renders on the directory card; set
   the copyright holder + marketplace `owner` to "Oracle Corporation"; moved the maker credit (Forward Deployed
   Engineering) into an internal `NOTICE` file (not surfaced on the listing).

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/README.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/README.md
@@ -5,7 +5,7 @@
 
 > **Canonical home:** [`oracle-samples/oracle-aidp-samples/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent`](https://github.com/oracle-samples/oracle-aidp-samples/tree/main/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent).
 > End users install via Anthropic's community marketplace (see [Install](#install)), which sources from this
-> canonical Oracle-org location; `ahmedawan-oracle/claude-code-plugins` is a personal pre-release mirror.
+> canonical Oracle-org location.
 
 Operate the entire Oracle AI Data Platform (AIDP) Workbench in natural language — a **37-skill** agent
 (not a single-engine orchestrator). It discovers your catalog into a grounding cache (FK/join hints +
@@ -26,26 +26,7 @@ AIDP REST API; interactive Spark-SQL / notebook cells run via the bundled `scrip
 > **Status:** **v0.5.0** — 37 skills across the AIDP data-engineering lifecycle (api_key **or** session-token auth). Endpoint + verification log:
 > [references/rest-endpoint-map.md](./references/rest-endpoint-map.md); change history: [CHANGELOG](./CHANGELOG.md).
 
-## Why this vs a pipeline orchestrator
-
-| Capability | This plugin | Astronomer (data-engineering / astronomer-data-agents) |
-|---|---|---|
-| Core scope | Operates an **entire AI data platform** — lakehouse + Spark compute + governance + AI/agents + MLOps + federation (37 skills) | Orchestrates **one engine** (Apache Airflow) + warehouse-read helpers |
-| Pipeline orchestration | Author DAG + cron, run, monitor, repair/retry/parameterize | **Theirs** — Airflow DAG authoring + failure RCA |
-| Airflow 2→3 migration · dbt · data lineage (incl. column-level) | Not offered (ours migrates **Databricks→AIDP**) | **Theirs** |
-| Full lakehouse SQL DDL/DML + Delta maintenance | CREATE…MERGE / OPTIMIZE / VACUUM / time-travel | Warehouse-read oriented |
-| Compute provisioning | Clusters + Compute/AI Compute, notebooks, Spark-UI debug | Astro/Airflow runtime |
-| **LLM-in-SQL (`ai_generate`)** | **Yes** | No equivalent |
-| **AI Agent Flows + guardrails** | **Yes** (13 node types) | No equivalent |
-| **Knowledge Bases / RAG + high-code agents** | **Yes** | No equivalent |
-| **Cross-source federation** | **Yes** (one Spark session) | No |
-| Platform governance | Roles, credentials, Delta Sharing, audit, MLOps, Git, bundles | Airflow connections/variables/pools |
-
-> Honest scope note: pipeline-orchestration depth, dbt/Cosmos, Airflow 2→3 migration, and data lineage
-> (including column-level) are Astronomer's strengths — this plugin is **additive** to your Oracle stack, not
-> a replacement for them or for Oracle FDI/OAC/OTBI/BIP.
-
----
+> **Additive to your Oracle stack** — complementary to Oracle FDI / OAC / OTBI / BIP, not a replacement.
 
 ## What it does
 
@@ -90,13 +71,6 @@ claude plugin marketplace add anthropics/claude-plugins-community
 claude plugin install  oracle-ai-data-platform-workbench-engineer-agent
 ```
 > Helper deps auto-install on first session (SessionStart hook) — no manual `pip` needed.
-
-Or from the personal development mirror (latest pre-release commits):
-
-```bash
-claude plugin marketplace add ahmedawan-oracle/claude-code-plugins
-claude plugin install  oracle-ai-data-platform-workbench-engineer-agent@oracle-ai-data-platform-workbench-suite
-```
 
 Then run the one-time bootstrap and catalog discovery:
 
@@ -173,7 +147,7 @@ PLUGIN: oracle-ai-data-platform-workbench-engineer-agent (37 skills)
 
 ### One-time setup (install + 2 commands)
 ```
-claude plugin marketplace add anthropics/claude-plugins-community     # (dev mirror: ahmedawan-oracle/claude-code-plugins)
+claude plugin marketplace add anthropics/claude-plugins-community
 claude plugin install  oracle-ai-data-platform-workbench-engineer-agent
    │
    ▼ first session: SessionStart hook auto-installs helper deps (oci/requests/websocket-client/cryptography)
@@ -219,10 +193,6 @@ NL request → [ROUTER] classify intent → select skill
   if present, is an optional accelerator only.
 - **No fabrication** — Preview/LA endpoints, the `ai_generate` signature, and federation semantics are
   flagged for live verification; nothing is asserted as confirmed without a recorded live result.
-
-## Out of scope (by design)
-- OCI networking (VCN/NAT/ACL), OAC registration, data lineage (no AIDP lineage API), and source-DB
-  connectors (use the spark-connectors plugin). DFL/Maxwell internals are excluded.
 
 ## License
 [MIT](./LICENSE) © 2026 Oracle Corporation

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-catalog-init/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-catalog-init/SKILL.md
@@ -6,7 +6,7 @@ description: One-time AIDP catalog discovery that writes a cached, version-contr
 # `aidp-catalog-init` — build the catalog grounding file
 
 Walk the AIDP catalog tree and generate `.aidp/catalog.md` — the cached, user-editable grounding file that
-makes subsequent NL-to-SQL fast and accurate (mirrors Astronomer's `warehouse-init` → `.astro/warehouse.md`).
+makes subsequent NL-to-SQL fast and accurate.
 Discovery is **pure control-plane** — **no SQL, no compute** (except optional `--with-counts`, which uses
 the bundled SQL helper). Self-contained: **no aidp MCP required**.
 

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-engineer-overview/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-engineer-overview/SKILL.md
@@ -66,7 +66,7 @@ does not require a bootstrap of any MCP server to run.
   via that plugin's **`aidp-connectors-bootstrap`** skill (pushes it to `/Workspace/Shared` via the AIDP MCP;
   if the MCP can't reach the instance, upload manually). A single external source needs only that connector
   skill (then author/run via `aidp-notebooks`); `aidp-federate` composes several for cross-source joins.
-- **OCI networking** (VCN/NAT/ACL), **OAC** dashboards/registration, **DFL/Maxwell** — not handled here.
+- **OCI networking** (VCN/NAT/ACL) and **OAC** dashboards/registration — not handled here.
 
 ## Shared environment & auth rules (every skill inherits these)
 - **Engine precedence — self-contained, no MCP/private-repo dependency.** For every CONTROL-PLANE op

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-migration/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-migration/SKILL.md
@@ -38,7 +38,7 @@ is required.
 - Common AIDP gotchas to apply during porting: `compute:///` defaultFS (executors can't write the driver
   FS; size APIs return 0 — measure via `oci://`), manifest commit semantics for external tables, and the
   `clusterName`-UUID pitfall when wiring jobs.
-- Keep scope to AIDP-native migration. DFL/Maxwell, OAC, and OCI networking are out of scope.
+- Keep scope to AIDP-native migration. OAC and OCI networking are out of scope.
 - This is a guided, human-confirmed process — no bulk automated conversion claims.
 
 ## References

--- a/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-pipelines/SKILL.md
+++ b/ai/claude-code-plugins/oracle-ai-data-platform-workbench-engineer-agent/skills/aidp-pipelines/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aidp-pipelines
-description: Author, schedule, run, and monitor AIDP Jobs (task DAGs of notebooks/python with cron). Use when the user wants to build a pipeline, create/update/run a Job, schedule a recurring run, check a run's status, read a task's output, or cancel a run. This is the AIDP analog of an Airflow DAG.
+description: Author, schedule, run, and monitor AIDP Jobs (task DAGs of notebooks/python with cron). Use when the user wants to build a pipeline, create/update/run a Job, schedule a recurring run, check a run's status, read a task's output, or cancel a run.
 ---
 
 # `aidp-pipelines` — AIDP Jobs (build, schedule, run, monitor)


### PR DESCRIPTION
## What

Documentation-only cleanup of the `oracle-ai-data-platform-workbench-engineer-agent` plugin to make the
canonical/public listing fully Oracle-owned and free of third-party-vendor and internal-product references.

**Changes (6 files, docs/skills only — no code, no behavior change):**
- **README.md** — removed the Astronomer comparison table, the Airflow/dbt mentions, the personal
  development-mirror install block, and the "Out of scope" section that named internal products.
- **CHANGELOG.md** — reworded the `0.4.7` entry to drop the competitor-comparison-table reference.
- **skills/aidp-engineer-overview/SKILL.md** & **skills/aidp-migration/SKILL.md** — removed internal-product
  (DFL/Maxwell) references from the out-of-scope notes; kept OCI-networking / OAC as the out-of-scope pointers.
- **skills/aidp-catalog-init/SKILL.md** — removed the "mirrors Astronomer's `warehouse-init`" parenthetical.
- **skills/aidp-pipelines/SKILL.md** — removed the "AIDP analog of an Airflow DAG" line from the description.

## Why

Tidies the plugin docs ahead of the Claude plugin-directory submission: the public listing should not
reference third-party orchestrators by name in a comparison table, should not advertise a personal dev mirror,
and must not surface internal Oracle product names. Verified: **zero** competitor (Astronomer/Airflow) and
**zero** internal-product (DFL/Maxwell) references remain anywhere in the shipped tree.

Closes #68

## Provenance / sign-off

- OCA sign-off present on the commit (`Signed-off-by: Ahmed Awan`).
- Follows #67 (the initial plugin contribution); this is the documentation-hygiene follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)