### PR TITLE
Add ALH sample: auto-fill columns missing from the insert DataFrame, application logging, and batch load

### DIFF
--- a/data-engineering/ingestion/ALH_DataFrame_Load_AutoFill_and_Logging.ipynb
+++ b/data-engineering/ingestion/ALH_DataFrame_Load_AutoFill_and_Logging.ipynb
@@ -8,7 +8,7 @@
     "language_info": {
       "name": "python"
     },
-    "Last_Active_Cell_Index": 0
+    "Last_Active_Cell_Index": 14
   },
   "nbformat_minor": 5,
   "nbformat": 4,
@@ -207,7 +207,7 @@
     {
       "id": "53b917e3",
       "cell_type": "code",
-      "source": "# Appendix (reference): performance-tuned write using documented connector options.\n# OFF by default -- running it inserts ANOTHER copy. Set RUN_TUNED_WRITE = True to try it.\nRUN_TUNED_WRITE = False\n\nif RUN_TUNED_WRITE:\n    # Range bounds for partitioning the write by the numeric key.\n    bounds = spark.table(target_table).selectExpr(\"min(SALE_ID) AS lo\", \"max(SALE_ID) AS hi\").first()\n    lo = int(bounds[\"lo\"]) if bounds[\"lo\"] is not None else 0\n    hi = int(bounds[\"hi\"]) if bounds[\"hi\"] is not None else (lo + num_rows)\n\n    (df_final.write\n        .option(\"write.mode\", \"MERGE\")\n        .option(\"write.merge.keys\", \"SALE_ID\")\n        .option(\"write.batch.size\", \"10000\")        # rows per write batch\n        .option(\"partition.column\", \"SALE_ID\")      # range-partitioned parallel write\n        .option(\"partition.num\", \"8\")               # number of parallel partitions\n        .option(\"partition.lower\", str(lo))\n        .option(\"partition.upper\", str(hi))\n        .option(\"skip.oos.staging\", \"true\")\n        .option(\"merge.staging.using.username\", \"true\")\n        .mode(\"append\")\n        .insertInto(target_table))\n\n    logger.info(\"Tuned write complete.\")\n    write_logs_to_volume()\nelse:\n    logger.info(\"Tuned write skipped (RUN_TUNED_WRITE = False).\")\n    write_logs_to_volume()",
+      "source": "# Appendix (reference): performance-tuned write using documented connector options.\n# OFF by default -- running it merge ANOTHER copy. Set RUN_TUNED_WRITE = True to try it.\nRUN_TUNED_WRITE = False\n\nif RUN_TUNED_WRITE:\n    # Range bounds for partitioning the write by the numeric key.\n    bounds = spark.table(target_table).selectExpr(\"min(SALE_ID) AS lo\", \"max(SALE_ID) AS hi\").first()\n    lo = int(bounds[\"lo\"]) if bounds[\"lo\"] is not None else 0\n    hi = int(bounds[\"hi\"]) if bounds[\"hi\"] is not None else (lo + num_rows)\n\n    (df_final.write\n        .option(\"write.mode\", \"MERGE\")\n        .option(\"write.merge.keys\", \"SALE_ID\")\n        .option(\"write.batch.size\", \"10000\")        # rows per write batch\n        .option(\"partition.column\", \"SALE_ID\")      # range-partitioned parallel write\n        .option(\"partition.num\", \"8\")               # number of parallel partitions\n        .option(\"partition.lower\", str(lo))\n        .option(\"partition.upper\", str(hi))\n        .option(\"skip.oos.staging\", \"true\")\n        .option(\"merge.staging.using.username\", \"true\")\n        .mode(\"append\")\n        .insertInto(target_table))\n\n    logger.info(\"Tuned write complete.\")\n    write_logs_to_volume()\nelse:\n    logger.info(\"Tuned write skipped (RUN_TUNED_WRITE = False).\")\n    write_logs_to_volume()",
       "metadata": {
         "command_metadata": {
           "end_time": 1781560389382.6213,

--- a/data-engineering/ingestion/ALH_DataFrame_Load_AutoFill_and_Logging.ipynb
+++ b/data-engineering/ingestion/ALH_DataFrame_Load_AutoFill_and_Logging.ipynb
@@ -1,0 +1,227 @@
+{
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "Last_Active_Cell_Index": 0
+  },
+  "nbformat_minor": 5,
+  "nbformat": 4,
+  "cells": [
+    {
+      "id": "7e20b272",
+      "cell_type": "markdown",
+      "source": "# ALH_DataFrame_Load_AutoFill_and_Logging — reusable patterns for loading a DataFrame into an Oracle table\n\nA **generic, customer-agnostic** notebook that highlights two reusable helpers layered on top\nof the standard AIDP connector write. For the **connector write mechanics themselves**\n(external-catalog read/write, `insertInto`, `MERGE`, and the full connector option list), see\nthe official samples under `data-engineering/ingestion/Read_Write_Oracle_Ecosystem_Connectors/`\nin [oracle-samples/oracle-aidp-samples](https://github.com/oracle-samples/oracle-aidp-samples).\n\n**What this demo adds on top of those samples:**\n\n1. **`align_to_target()`** — build only the columns that carry values. The helper reads the\n   live table schema, fills any missing column with a typed `NULL`, casts each column to the\n   table's type, and orders them to the table — so positional `insertInto` always lines up and\n   you never hand-maintain null columns.\n2. **Reliable Volume logging + `post_run_cell` hook** — write logs to a local file and copy the\n   complete log to a Volume with an explicit close, after each step / on completion / on error /\n   after every cell, so logs are captured even if a step fails.\n\nIt also shows in-notebook dummy data and surrogate-key generation, and ends with a\n**performance-tuning reference** using the documented connector options\n(`write.batch.size`, `partition.*`, `fetch.size`).\n\n**Target table:** `ext_private_catalog_aidp_user.coder.sales_demo`",
+      "metadata": {}
+    },
+    {
+      "id": "f005753e",
+      "cell_type": "markdown",
+      "source": "## Prerequisites\n\nCreate the target table in **ADW** (run as the schema owner, e.g. `coder`), then **refresh the\n`ext_private_catalog_aidp_user` catalog** in AIDP so the table is visible to this notebook.\n\n```sql\nCREATE TABLE sales_demo (\n    SALE_ID           NUMBER            NOT NULL,\n    ORDER_NUMBER      VARCHAR2(50 BYTE),\n    CUSTOMER_ID       NUMBER,\n    CUSTOMER_NAME     VARCHAR2(100 BYTE),\n    PRODUCT_CODE      VARCHAR2(50 BYTE),\n    PRODUCT_CATEGORY  VARCHAR2(50 BYTE),\n    QUANTITY          NUMBER(10,0),\n    UNIT_PRICE        NUMBER(15,2),\n    TOTAL_AMOUNT      NUMBER(15,2),\n    CURRENCY_CODE     VARCHAR2(3 BYTE),\n    SALE_DATE         DATE,\n    REGION            VARCHAR2(50 BYTE),\n    SALES_REP         VARCHAR2(100 BYTE),\n    STATUS            VARCHAR2(20 BYTE),\n    W_INSERT_DT       TIMESTAMP(6),\n    W_UPDATE_DT       TIMESTAMP(6),\n    ETL_BATCH_ID      NUMBER(12,0),\n    SOURCE_SYSTEM     VARCHAR2(30 BYTE),\n    INTEGRATION_ID    VARCHAR2(100 BYTE),\n    COMMENTS          VARCHAR2(4000 BYTE),\n    CONSTRAINT PK_SALES_DEMO PRIMARY KEY (SALE_ID)\n);\n```\n\nOptionally grant access to the catalog identity used to run the notebook:\n\n```sql\nGRANT SELECT, INSERT ON sales_demo TO aidp_user;\n```",
+      "metadata": {}
+    },
+    {
+      "id": "dfcc1b4c",
+      "cell_type": "code",
+      "source": "# Cell 1: Import Libraries\nimport logging\nimport io\nimport os\nimport shutil\nimport atexit\nfrom datetime import datetime\nfrom pyspark.sql import DataFrame\nfrom pyspark.sql import functions as F\nfrom pyspark.sql.functions import col, lit, current_timestamp, row_number, monotonically_increasing_id\nfrom pyspark.sql.types import DecimalType, StringType\nfrom pyspark.sql.window import Window",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560344863.7197,
+          "start_time": 1781560341186.558
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:10.218Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 33
+    },
+    {
+      "id": "ef2b49a2",
+      "cell_type": "markdown",
+      "source": "## Reliable logging to a Volume\n\nThis pattern writes application logs to a **local file** during the run, then copies the\ncomplete log to the workspace **Volume** using an explicit `open` / `write` / `flush` /\n`fsync` / `close` cycle. Writing locally first and copying with an explicit close is a\nsimple, portable way to make sure the log file is fully written and reliably persisted to\nthe Volume. The copy runs progressively, on completion, on error (`finally`), on interpreter\nexit (`atexit`), and after every cell (`post_run_cell`), so logs are captured even if a step\nfails.",
+      "metadata": {}
+    },
+    {
+      "id": "9398a841",
+      "cell_type": "code",
+      "source": "# Cell 2: Setup Logging (in-memory stream + Volume .log, commit-on-close safe)\nlog_stream = io.StringIO()\n\nRUN_ID   = datetime.now().strftime(\"%Y%m%d_%H%M%S\")\nLOG_NAME = f\"ALH_SALES_LOAD_DEMO_{RUN_ID}.log\"\n\nlog_volume_dir = \"/Volumes/std_catalog/bronze/logs\"     # Volume backing the log folder; Here, logs is the AIDP volume referring a folder in object storage location\nos.makedirs(log_volume_dir, exist_ok=True)\nlog_file_path  = f\"{log_volume_dir}/{LOG_NAME}\"\nlocal_log_path = f\"/tmp/{LOG_NAME}\"                       # local POSIX staging\n\nlog_formatter = logging.Formatter(\"%(asctime)s [%(levelname)s] %(message)s\")\n\nlogger = logging.getLogger(\"SALES_LOAD_DEMO\")\nlogger.setLevel(logging.INFO)\nlogger.propagate = False\n\n# Re-run safe: close (not just clear) any handlers from a previous run.\nfor _h in logger.handlers[:]:\n    try:\n        _h.close()\n    finally:\n        logger.removeHandler(_h)\n\nstream_handler = logging.StreamHandler(log_stream)\nstream_handler.setLevel(logging.INFO)\nstream_handler.setFormatter(log_formatter)\n\nfile_handler = logging.FileHandler(local_log_path, mode=\"w\")\nfile_handler.setLevel(logging.INFO)\nfile_handler.setFormatter(log_formatter)\n\nlogger.addHandler(stream_handler)\nlogger.addHandler(file_handler)\n\ndef write_logs_to_volume():\n    \"\"\"Copy the current local log to the Volume in one open/write/fsync/close cycle\n    so the destination file is fully written and flushed. Safe to call repeatedly;\n    does not close the logger.\"\"\"\n    try:\n        file_handler.flush()\n        if os.path.exists(local_log_path):\n            with open(local_log_path, \"rb\") as src, open(log_file_path, \"wb\") as dst:\n                shutil.copyfileobj(src, dst)\n                dst.flush()\n                try:\n                    os.fsync(dst.fileno())\n                except OSError:\n                    pass\n    except Exception as e:\n        print(f\"WARN: could not write logs to Volume: {e}\")\n\n# Backstop 1: commit on kernel exit.\natexit.register(write_logs_to_volume)\n\n# Backstop 2: commit after EVERY cell (success or failure).\ndef _commit_logs_post_cell(result=None):\n    write_logs_to_volume()\ntry:\n    _ip = get_ipython()\n    if _ip is not None and not globals().get(\"_log_hook_registered\", False):\n        _ip.events.register(\"post_run_cell\", _commit_logs_post_cell)\n        globals()[\"_log_hook_registered\"] = True\nexcept Exception:\n    pass\n\nlogger.info(\"Logging initialized.\")\nlogger.info(f\"Volume log file: {log_file_path}\")\nwrite_logs_to_volume()",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560350167.7256,
+          "start_time": 1781560346042.6072
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:15.761Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 34
+    },
+    {
+      "id": "b50850ca",
+      "cell_type": "code",
+      "source": "# Cell 3: Configuration\ntarget_table = \"ext_private_catalog_aidp_user.coder.sales_demo\"\nnum_rows     = 22000\nbatch_id     = int(datetime.now().strftime(\"%y%m%d%H%M%S\"))   # 12-digit numeric batch id\n\nspark.conf.set(\"spark.sql.legacy.timeParserPolicy\", \"LEGACY\")\n\nlogger.info(f\"Target table : {target_table}\")\nlogger.info(f\"Dummy rows   : {num_rows}\")\nlogger.info(f\"ETL batch id : {batch_id}\")",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560354511.7195,
+          "start_time": 1781560351372.0728
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:20.467Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 35
+    },
+    {
+      "id": "c2be4694",
+      "cell_type": "markdown",
+      "source": "## `align_to_target()` — the key reusable helper\n\n`insertInto()` matches columns **by position**, so the DataFrame must provide *every* table\ncolumn, in table order. Rather than hand-add null columns and a manual `.select(...)`, this\nhelper reads the live table schema and: keeps every target column in order, casts each to the\ntable's datatype, fills any column not in the DataFrame with a typed `NULL`, and drops extras.",
+      "metadata": {}
+    },
+    {
+      "id": "70bebf91",
+      "cell_type": "code",
+      "source": "# Cell 4: Helper - align a DataFrame to the target table schema\ndef align_to_target(df: DataFrame, target_table: str) -> DataFrame:\n    target_schema = spark.table(target_table).schema\n    src = {c.lower(): c for c in df.columns}          # case-insensitive match\n    return df.select([\n        (col(src[f.name.lower()]) if f.name.lower() in src else lit(None))\n            .cast(f.dataType).alias(f.name)\n        for f in target_schema.fields\n    ])",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560359175.532,
+          "start_time": 1781560355818.2515
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:24.883Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 36
+    },
+    {
+      "id": "7aec90c5",
+      "cell_type": "markdown",
+      "source": "## Generate dummy SALES data — only the columns that carry values\n\nNote we deliberately **do not** create `INTEGRATION_ID` or `COMMENTS`. `align_to_target()`\nfills them with typed `NULL` automatically — demonstrating that you only code the columns\nyou actually have data for.",
+      "metadata": {}
+    },
+    {
+      "id": "586e8055",
+      "cell_type": "code",
+      "source": "# Cell 5: Generate dummy SALES data (value-bearing columns only)\ndf = (spark.range(1, num_rows + 1).withColumnRenamed(\"id\", \"seq\")\n    .withColumn(\"ORDER_NUMBER\",     F.concat(F.lit(\"ORD\"), (F.lit(100000) + F.col(\"seq\")).cast(\"string\")))\n    .withColumn(\"CUSTOMER_ID\",      (F.lit(1000) + (F.col(\"seq\") % 500)))\n    .withColumn(\"CUSTOMER_NAME\",    F.concat(F.lit(\"Customer \"), (F.col(\"seq\") % 500).cast(\"string\")))\n    .withColumn(\"PRODUCT_CODE\",     F.concat(F.lit(\"P\"), (F.col(\"seq\") % 200).cast(\"string\")))\n    .withColumn(\"PRODUCT_CATEGORY\", F.concat(F.lit(\"CAT\"), (F.col(\"seq\") % 5).cast(\"string\")))\n    .withColumn(\"QUANTITY\",         (F.lit(1) + (F.col(\"seq\") % 100)))\n    .withColumn(\"UNIT_PRICE\",       F.round((F.col(\"seq\") % 100 + F.lit(1)) * F.lit(9.99), 2))\n    .withColumn(\"TOTAL_AMOUNT\",     F.round(F.col(\"QUANTITY\") * F.col(\"UNIT_PRICE\"), 2))\n    .withColumn(\"CURRENCY_CODE\",    F.lit(\"USD\"))\n    .withColumn(\"SALE_DATE\",        F.expr(\"date_add(DATE'2024-01-01', cast(seq % 365 as int))\"))\n    .withColumn(\"REGION\",           F.concat(F.lit(\"Region-\"), (F.col(\"seq\") % 4).cast(\"string\")))\n    .withColumn(\"SALES_REP\",        F.concat(F.lit(\"Rep \"), (F.col(\"seq\") % 20).cast(\"string\")))\n    .withColumn(\"STATUS\",           F.lit(\"COMPLETED\"))\n    .withColumn(\"W_INSERT_DT\",      current_timestamp())\n    .withColumn(\"W_UPDATE_DT\",      current_timestamp())\n    .withColumn(\"ETL_BATCH_ID\",     F.lit(batch_id))\n    .withColumn(\"SOURCE_SYSTEM\",    F.lit(\"DEMO\"))\n    .drop(\"seq\"))\n\nlogger.info(f\"Generated dummy sales rows; value columns: {df.columns}\")\ndf.show(5, truncate=False)\nwrite_logs_to_volume()   # commit logs after the data-generation step",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560364480.5845,
+          "start_time": 1781560360494.0156
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:29.875Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": "+------------+-----------+-------------+------------+----------------+--------+----------+------------+-------------+----------+--------+---------+---------+--------------------------+--------------------------+------------+-------------+\n|ORDER_NUMBER|CUSTOMER_ID|CUSTOMER_NAME|PRODUCT_CODE|PRODUCT_CATEGORY|QUANTITY|UNIT_PRICE|TOTAL_AMOUNT|CURRENCY_CODE|SALE_DATE |REGION  |SALES_REP|STATUS   |W_INSERT_DT               |W_UPDATE_DT               |ETL_BATCH_ID|SOURCE_SYSTEM|\n+------------+-----------+-------------+------------+----------------+--------+----------+------------+-------------+----------+--------+---------+---------+--------------------------+--------------------------+------------+-------------+\n|ORD100001   |1001       |Customer 1   |P1          |CAT1            |2       |19.98     |39.96       |USD          |2024-01-02|Region-1|Rep 1    |COMPLETED|2026-06-15 21:52:43.257541|2026-06-15 21:52:43.257541|260615215233|DEMO         |\n|ORD100002   |1002       |Customer 2   |P2          |CAT2            |3       |29.97     |89.91       |USD          |2024-01-03|Region-2|Rep 2    |COMPLETED|2026-06-15 21:52:43.257541|2026-06-15 21:52:43.257541|260615215233|DEMO         |\n|ORD100003   |1003       |Customer 3   |P3          |CAT3            |4       |39.96     |159.84      |USD          |2024-01-04|Region-3|Rep 3    |COMPLETED|2026-06-15 21:52:43.257541|2026-06-15 21:52:43.257541|260615215233|DEMO         |\n|ORD100004   |1004       |Customer 4   |P4          |CAT4            |5       |49.95     |249.75      |USD          |2024-01-05|Region-0|Rep 4    |COMPLETED|2026-06-15 21:52:43.257541|2026-06-15 21:52:43.257541|260615215233|DEMO         |\n|ORD100005   |1005       |Customer 5   |P5          |CAT0            |6       |59.94     |359.64      |USD          |2024-01-06|Region-1|Rep 5    |COMPLETED|2026-06-15 21:52:43.257541|2026-06-15 21:52:43.257541|260615215233|DEMO         |\n+------------+-----------+-------------+------------+----------------+--------+----------+------------+-------------+----------+--------+---------+---------+--------------------------+--------------------------+------------+-------------+\nonly showing top 5 rows\n\n"
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "execution_count": 37
+    },
+    {
+      "id": "bbf38bdb",
+      "cell_type": "markdown",
+      "source": "## Generate the surrogate key, align to the table, and APPEND\n\n`SALE_ID` continues from the current `max()` in the table. `align_to_target()` then fills\n`INTEGRATION_ID`/`COMMENTS` as typed `NULL`, casts every column to the table type, and orders\nto the table. The load is wrapped in `try/except/finally` so logs are committed to the Volume\nas soon as this step completes — success or failure.",
+      "metadata": {}
+    },
+    {
+      "id": "fc82e80e",
+      "cell_type": "code",
+      "source": "# Cell 6: Generate SALE_ID, align to target schema, and APPEND\ntry:\n    max_id_row = spark.table(target_table).selectExpr(\"max(SALE_ID)\").first()[0]\n    max_id     = int(max_id_row) if max_id_row is not None else 0\n    logger.info(f\"Current max SALE_ID: {max_id}. New rows start at {max_id + 1}.\")\n\n    window_spec = Window.orderBy(monotonically_increasing_id())\n    df = df.withColumn(\"SALE_ID\", (row_number().over(window_spec) + max_id).cast(DecimalType(38, 0)))\n\n    # Fills INTEGRATION_ID + COMMENTS as typed NULL; casts to table types; orders to table.\n    df_final = align_to_target(df, target_table)\n\n    logger.info(\"Final schema being written:\")\n    for f in df_final.schema.fields:\n        logger.info(f\"  {f.name}: {f.dataType.simpleString()}\")\n\n    (df_final.write\n        .option(\"skip.oos.staging\", \"true\")\n        .option(\"merge.staging.using.username\", \"true\")\n        .mode(\"append\")\n        .insertInto(target_table))\n\n    logger.info(f\"APPEND complete: wrote {df_final.count()} rows to {target_table}.\")\nexcept Exception:\n    logger.exception(\"Run failed during load step.\")\n    raise\nfinally:\n    write_logs_to_volume()",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560379672.915,
+          "start_time": 1781560365705.892
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:42.668Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 38
+    },
+    {
+      "id": "f00fa258",
+      "cell_type": "code",
+      "source": "# Cell 7: Final commit + print\nwrite_logs_to_volume()\nprint(log_stream.getvalue())\nprint(f\"Logs written to: {log_file_path}\")",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560384549.1667,
+          "start_time": 1781560380871.3132
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:47.501Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [
+        {
+          "data": {
+            "text/plain": "2026-06-15 21:52:28,363 [INFO] Logging initialized.\n2026-06-15 21:52:28,364 [INFO] Volume log file: /Volumes/std_catalog/bronze/logs/ALH_SALES_LOAD_DEMO_20260615_215228.log\n2026-06-15 21:52:33,816 [INFO] Target table : ext_private_catalog_aidp_user.coder.sales_demo\n2026-06-15 21:52:33,816 [INFO] Dummy rows   : 22000\n2026-06-15 21:52:33,816 [INFO] ETL batch id : 260615215233\n2026-06-15 21:52:43,242 [INFO] Generated dummy sales rows; value columns: [\"ORDER_NUMBER\", \"CUSTOMER_ID\", \"CUSTOMER_NAME\", \"PRODUCT_CODE\", \"PRODUCT_CATEGORY\", \"QUANTITY\", \"UNIT_PRICE\", \"TOTAL_AMOUNT\", \"CURRENCY_CODE\", \"SALE_DATE\", \"REGION\", \"SALES_REP\", \"STATUS\", \"W_INSERT_DT\", \"W_UPDATE_DT\", \"ETL_BATCH_ID\", \"SOURCE_SYSTEM\"]\n2026-06-15 21:52:50,867 [INFO] Current max SALE_ID: 66400. New rows start at 66401.\n2026-06-15 21:52:51,055 [INFO] Final schema being written:\n2026-06-15 21:52:51,055 [INFO]   sale_id: decimal(38,10)\n2026-06-15 21:52:51,055 [INFO]   order_number: string\n2026-06-15 21:52:51,055 [INFO]   customer_id: decimal(38,10)\n2026-06-15 21:52:51,056 [INFO]   customer_name: string\n2026-06-15 21:52:51,056 [INFO]   product_code: string\n2026-06-15 21:52:51,056 [INFO]   product_category: string\n2026-06-15 21:52:51,056 [INFO]   quantity: decimal(10,0)\n2026-06-15 21:52:51,056 [INFO]   unit_price: decimal(15,2)\n2026-06-15 21:52:51,056 [INFO]   total_amount: decimal(15,2)\n2026-06-15 21:52:51,056 [INFO]   currency_code: string\n2026-06-15 21:52:51,056 [INFO]   sale_date: timestamp\n2026-06-15 21:52:51,056 [INFO]   region: string\n2026-06-15 21:52:51,056 [INFO]   sales_rep: string\n2026-06-15 21:52:51,056 [INFO]   status: string\n2026-06-15 21:52:51,056 [INFO]   w_insert_dt: timestamp\n2026-06-15 21:52:51,056 [INFO]   w_update_dt: timestamp\n2026-06-15 21:52:51,056 [INFO]   etl_batch_id: decimal(12,0)\n2026-06-15 21:52:51,056 [INFO]   source_system: string\n2026-06-15 21:52:51,056 [INFO]   integration_id: string\n2026-06-15 21:52:51,056 [INFO]   comments: string\n2026-06-15 21:52:58,120 [INFO] APPEND complete: wrote 22000 rows to ext_private_catalog_aidp_user.coder.sales_demo.\n\nLogs written to: /Volumes/std_catalog/bronze/logs/ALH_SALES_LOAD_DEMO_20260615_215228.log\n"
+          },
+          "metadata": {},
+          "output_type": "display_data"
+        }
+      ],
+      "execution_count": 39
+    },
+    {
+      "id": "e4873d07",
+      "cell_type": "markdown",
+      "source": "## Appendix — performance tuning with connector options (reference)\n\nFor larger loads, the AIDP connector exposes options for **parallelism** and **batching**\n(documented in the official `Read_Write_Oracle_Ecosystem_Connectors` samples). For this\n200-row demo the basic write above is enough, so the cell below is **off by default**.\n\n| Option | Applies to | Purpose |\n| --- | --- | --- |\n| `fetch.size` | read | rows fetched per round-trip |\n| `write.batch.size` | write | rows written per batch |\n| `partition.column` | read / write | numeric or date column for range partitioning |\n| `partition.num` | read / write | number of parallel partitions |\n| `partition.lower` / `partition.upper` | read / write | range bounds for the partition column |\n\n**Tuned read (parallel, larger fetch):**\n```python\ndf = (spark.read.format(\"aidataplatform\")\n    .option(\"catalog.id\", \"<external_catalog_id>\")\n    .option(\"schema\", \"coder\").option(\"table\", \"sales_demo\")\n    .option(\"fetch.size\", \"10000\")\n    .option(\"partition.column\", \"SALE_ID\")\n    .option(\"partition.num\", \"8\")\n    .option(\"partition.lower\", str(lo)).option(\"partition.upper\", str(hi))\n    .load())\n```\nThe runnable, range-partitioned/batched **write** example is in the next cell.",
+      "metadata": {}
+    },
+    {
+      "id": "53b917e3",
+      "cell_type": "code",
+      "source": "# Appendix (reference): performance-tuned write using documented connector options.\n# OFF by default -- running it inserts ANOTHER copy. Set RUN_TUNED_WRITE = True to try it.\nRUN_TUNED_WRITE = False\n\nif RUN_TUNED_WRITE:\n    # Range bounds for partitioning the write by the numeric key.\n    bounds = spark.table(target_table).selectExpr(\"min(SALE_ID) AS lo\", \"max(SALE_ID) AS hi\").first()\n    lo = int(bounds[\"lo\"]) if bounds[\"lo\"] is not None else 0\n    hi = int(bounds[\"hi\"]) if bounds[\"hi\"] is not None else (lo + num_rows)\n\n    (df_final.write\n        .option(\"write.mode\", \"MERGE\")\n        .option(\"write.merge.keys\", \"SALE_ID\")\n        .option(\"write.batch.size\", \"10000\")        # rows per write batch\n        .option(\"partition.column\", \"SALE_ID\")      # range-partitioned parallel write\n        .option(\"partition.num\", \"8\")               # number of parallel partitions\n        .option(\"partition.lower\", str(lo))\n        .option(\"partition.upper\", str(hi))\n        .option(\"skip.oos.staging\", \"true\")\n        .option(\"merge.staging.using.username\", \"true\")\n        .mode(\"append\")\n        .insertInto(target_table))\n\n    logger.info(\"Tuned write complete.\")\n    write_logs_to_volume()\nelse:\n    logger.info(\"Tuned write skipped (RUN_TUNED_WRITE = False).\")\n    write_logs_to_volume()",
+      "metadata": {
+        "command_metadata": {
+          "end_time": 1781560389382.6213,
+          "start_time": 1781560385726.9946
+        },
+        "execution": {
+          "iopub.status.busy": "2026-06-15T21:31:52.413Z"
+        },
+        "is_cancelled": null,
+        "result_type": null,
+        "trusted": true
+      },
+      "outputs": [],
+      "execution_count": 40
+    }
+  ]
+}


### PR DESCRIPTION
# Description

Adds a new, generic (customer-agnostic) Oracle AI Data Platform Workbench sample notebook — ALH_DataFrame_Load_AutoFill_and_Logging.ipynb — demonstrating three reusable patterns for loading a Spark DataFrame into an Autonomous AI Lakehouse (ALH) external-catalog Oracle table:

1. Auto-fill values for columns that have no value in the insert — a small align_to_target() helper reads the live table schema and builds the write DataFrame from only the columns that carry values; any column not present is filled with a typed NULL, every column is cast to the table's datatype, and columns are ordered to match the table. This lets a positional insertInto succeed without hand-maintaining empty/NULL columns.

2. Application logging — logs are written to a local file during the run and copied to a workspace Volume with an explicit close, committed progressively, on completion, on error (finally), on interpreter exit (atexit), and after every cell (post_run_cell) so logs are reliably persisted even if a step fails.

3. Batch load — a performance-tuning reference using the documented connector options (write.batch.size, partition.column/num/lower/upper, fetch.size) for batched, range-partitioned reads and writes.
The notebook generates its own dummy data (no source files) and includes the target-table DDL in a Prerequisites cell, so it runs standalone. It complements the existing data-engineering/ingestion/Read_Write_Oracle_Ecosystem_Connectors/ samples by adding the schema-auto-fill and reliable-logging patterns that those samples do not cover.

**Dependencies:**

An AIDP Workbench workspace with an Autonomous AI Lakehouse external catalog (e.g., ext_private_catalog_aidp_user).
The target table created via the DDL in the notebook's Prerequisites cell (sales_demo), and a catalog refresh so it's visible.
Standard PySpark in the AIDP cluster runtime. No new Python packages.

**Fixes #** (N/A)

## Type of change

- [x] To explain the the feature and sample code

# How Has This Been Tested?

Ran the notebook end-to-end on an AIDP Workbench cluster against an Autonomous AI Lakehouse external catalog.

Test A — Schema auto-fill + load: Created coder.sales_demo via the Prerequisites DDL and refreshed the catalog; ran all cells. The notebook generated 22000 dummy rows and appended them to ext_private_catalog_aidp_user.coder.sales_demo. Verified SELECT COUNT(*) increased by 22000 and that the columns omitted from the DataFrame (INTEGRATION_ID, COMMENTS) were stored as NULL, with all other columns populated and correctly typed.

Test B — Application logging / fail-safe: Confirmed a timestamped log file was written to the Volume (/Volumes/std_catalog/bronze/logs/…) containing every step. Deliberately raised an error in a cell and confirmed the log file still contained all entries up to the failure (via the post_run_cell + finally commits).

**Test Configuration**:

AIDP Workbench: Autonomous AI Lakehouse external catalog
Spark / PySpark: cluster default (Spark 3.5)
Database: OCI Autonomous Data Warehouse (target accessed via the external catalog connector)
Firmware version: N/A
Hardware: N/A
Toolchain: N/A
SDK: N/A


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
