### PR TITLE
Add miscellaneous sample: working with Spark SQL table properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ Combines Delta UniForm with Apache Iceberg Liquid Clustering for open-format, cr
 | [DataFrame PII Masking with AI](data-engineering/transformation/masking/README.md) | PySpark utility that detects and masks PII columns using a pluggable `PIIChecker` abstraction — supports Anthropic Claude (Haiku/Sonnet/Opus) and OCI native models via Spark `query_model()`. |
 | [Partition-Aware Merge Generator](data-engineering/transformation/merge/README.md) | Helper utility for partition-aware merge operations on Spark DataFrames: PK-based updates, configurable update policies, deletes, and schema evolution — Delta-MERGE-like behaviour without requiring Delta. |
 
+#### Miscellaneous
+
+| Sample | Description |
+|---|---|
+| [Working with Table Properties](data-engineering/miscellaneous/README.md) | Manage Spark SQL table properties on a managed Delta table — set, read, overwrite, and remove properties, and store structured JSON metadata as a property value. |
+
 ---
 
 ### AI & Machine Learning

--- a/data-engineering/miscellaneous/README.md
+++ b/data-engineering/miscellaneous/README.md
@@ -1,0 +1,66 @@
+# Working with Spark SQL Table Properties
+
+This sample demonstrates how to manage **table properties** — arbitrary `key = value`
+metadata attached to a table — from a Spark notebook on the Oracle AI Data Platform (AIDP)
+lakehouse. Table properties are a convenient place to record ownership, data-classification
+labels, lineage hints, or any custom governance metadata so the context travels with the
+data itself.
+
+The notebook walks through the full lifecycle of a property on a managed **Delta** table:
+
+1. Create a demo table.
+2. Inspect the engine-managed default properties (`SHOW TBLPROPERTIES`).
+3. Store **structured (JSON) metadata** in a property (`json.dumps` → string value).
+4. Read a property back — as a DataFrame, as a Python dict, and as a single raw value.
+5. Overwrite an existing property (`SET TBLPROPERTIES` again).
+6. Remove a property (`UNSET TBLPROPERTIES IF EXISTS`).
+
+The sample artifact is:
+
+- [working_with_table_properties.ipynb](./working_with_table_properties.ipynb)
+
+The notebook keeps its captured outputs, so you can read the expected results on GitHub
+without running it.
+
+## Key idea: values are strings
+
+Table-property values are always stored as **strings**. To attach structured metadata,
+serialize a Python object with `json.dumps(...)` and store that JSON string; read it back
+with `json.loads(...)`.
+
+## Common operations
+
+```python
+# Set (or overwrite) a property
+spark.sql("ALTER TABLE <catalog>.<schema>.<table> SET TBLPROPERTIES ('owner' = 'team-x')")
+
+# Read all properties, or just one
+spark.sql("SHOW TBLPROPERTIES <catalog>.<schema>.<table>").show(truncate=False)
+spark.sql("SHOW TBLPROPERTIES <catalog>.<schema>.<table> ('owner')").show(truncate=False)
+
+# Remove a property (IF EXISTS keeps it idempotent)
+spark.sql("ALTER TABLE <catalog>.<schema>.<table> UNSET TBLPROPERTIES IF EXISTS ('owner')")
+```
+
+## Prerequisites
+
+- A Spark environment with Delta support (e.g. AIDP Workbench with an active compute).
+- An active Spark session (`spark`) — already provided inside an AIDP notebook.
+
+## Tested environment
+
+- AIDP Workbench
+- Apache Spark 3.5.0 + Delta Lake
+
+## Cleanup
+
+The demo table is tiny and harmless, but you can drop it when finished:
+
+```python
+spark.sql("DROP TABLE IF EXISTS default.default.test_table_prop")
+```
+
+## Reference
+
+- Spark SQL `ALTER TABLE ... SET/UNSET TBLPROPERTIES`:
+  https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-alter-table.html

--- a/data-engineering/miscellaneous/README.md
+++ b/data-engineering/miscellaneous/README.md
@@ -47,10 +47,11 @@ spark.sql("ALTER TABLE <catalog>.<schema>.<table> UNSET TBLPROPERTIES IF EXISTS 
 - A Spark environment with Delta support (e.g. AIDP Workbench with an active compute).
 - An active Spark session (`spark`) — already provided inside an AIDP notebook.
 
-## Tested environment
+## Environment
 
-- AIDP Workbench
-- Apache Spark 3.5.0 + Delta Lake
+The notebook outputs were captured from a run in **AIDP Workbench**, whose Spark
+runtime is Apache Spark 3.5.0 with Delta Lake. The operations are standard Spark
+SQL and not specific to that version.
 
 ## Cleanup
 

--- a/data-engineering/miscellaneous/working_with_table_properties.ipynb
+++ b/data-engineering/miscellaneous/working_with_table_properties.ipynb
@@ -1,0 +1,418 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "59007b0c",
+   "metadata": {},
+   "source": [
+    "# Working with Spark SQL Table Properties\n",
+    "\n",
+    "Table properties are arbitrary `key = value` metadata that you can attach to a table. They are handy for recording ownership, data-classification labels, lineage hints, or any custom governance metadata **alongside the table itself** — so the context travels with the data instead of living in a separate system.\n",
+    "\n",
+    "This notebook walks through the full lifecycle of a table property on the Oracle AI Data Platform (AIDP) lakehouse using a managed **Delta** table:\n",
+    "\n",
+    "1. Create a demo table\n",
+    "2. Inspect the engine-managed default properties\n",
+    "3. Store **structured (JSON) metadata** in a property\n",
+    "4. Read properties back (as a DataFrame, as a dict, and a single value)\n",
+    "5. Overwrite an existing property\n",
+    "6. Remove a property\n",
+    "\n",
+    "> The cells use plain Spark SQL via `spark.sql(...)`, so the same patterns work in any Spark notebook. The outputs shown below were captured from an actual AIDP run.\n",
+    "\n",
+    "**Prerequisite:** an active Spark session (`spark`) — already provided inside an AIDP notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dc03c4d",
+   "metadata": {},
+   "source": [
+    "## 1. Create a demo table\n",
+    "\n",
+    "We use a fully-qualified name `<catalog>.<schema>.<table>`. `CREATE TABLE IF NOT EXISTS` makes the cell **idempotent** — safe to re-run without error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "54276915",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# A fully-qualified table name: <catalog>.<schema>.<table>.\n",
+    "# On AIDP this creates a managed Delta table in the lakehouse.\n",
+    "table = \"default.default.test_table_prop\"\n",
+    "\n",
+    "# IF NOT EXISTS makes this cell safe to re-run (idempotent).\n",
+    "spark.sql(f\"CREATE TABLE IF NOT EXISTS {table}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "392b55da",
+   "metadata": {},
+   "source": [
+    "## 2. Inspect the default properties\n",
+    "\n",
+    "`SHOW TBLPROPERTIES <table>` lists every property as a `(key, value)` row. A freshly created Delta table already carries a few **engine-managed** defaults (the `delta.*` protocol versions and `option.*` entries) — you don't set these yourself."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ed13c4af",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+---------------------------+-------+\n",
+       "|key                        |value  |\n",
+       "+---------------------------+-------+\n",
+       "|delta.minReaderVersion     |1      |\n",
+       "|delta.minWriterVersion     |2      |\n",
+       "|option.catalog.id          |default|\n",
+       "|option.serialization.format|1      |\n",
+       "+---------------------------+-------+\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# SHOW TBLPROPERTIES returns every property as a (key, value) row.\n",
+    "# Newly created Delta tables already carry engine-managed defaults\n",
+    "# (delta.minReaderVersion, delta.minWriterVersion, ...).\n",
+    "props_df = spark.sql(f\"SHOW TBLPROPERTIES {table}\")\n",
+    "props_df.show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "967c52af",
+   "metadata": {},
+   "source": [
+    "## 3. Store structured (JSON) metadata in a property\n",
+    "\n",
+    "Property **values are always strings**. To attach structured metadata (nested dicts, lists), serialize a Python object to a JSON string with `json.dumps(...)` and store *that string*. You can parse it back later with `json.loads(...)`.\n",
+    "\n",
+    "> **Quoting caution:** here the JSON happens to use double quotes, so it nests cleanly inside the single-quoted SQL literal. If a value could itself contain a single quote, escape it (or use a parameterized approach) to avoid breaking the SQL statement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4a6323c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- save json in table property as string ---\n",
+    "# Table-property VALUES are always strings, so to attach structured metadata\n",
+    "# we serialize a Python dict to a JSON string and store that string.\n",
+    "import json\n",
+    "\n",
+    "table_property_dict = {\n",
+    "    \"owner\": \"the_owner\",\n",
+    "    \"labels\": [\"test\", \"extra\"],\n",
+    "    \"position\": {\"region\": {\"dc\": \"region_dc\", \"az\": \"region_az\"}}\n",
+    "}\n",
+    "\n",
+    "# json.dumps -> compact JSON text that round-trips back to a dict later.\n",
+    "table_property_val = json.dumps(table_property_dict)\n",
+    "\n",
+    "# ALTER TABLE ... SET TBLPROPERTIES adds (or replaces) the named property.\n",
+    "spark.sql(f\"\"\"\n",
+    "    ALTER TABLE {table}\n",
+    "    SET TBLPROPERTIES (\n",
+    "        'custom-details' = '{table_property_val}'\n",
+    "    )\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "053b1e4d",
+   "metadata": {},
+   "source": [
+    "## 4. Read the property back\n",
+    "\n",
+    "There are a few ways to read properties, depending on what you need."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b16a7cc",
+   "metadata": {},
+   "source": [
+    "### As a DataFrame (filter to one key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1551ef24",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+--------------+-------------------------------------------------------------------------------------------------------------------+\n",
+       "|key           |value                                                                                                              |\n",
+       "+--------------+-------------------------------------------------------------------------------------------------------------------+\n",
+       "|custom-details|{\"owner\": \"the_owner\", \"labels\": [\"test\", \"extra\"], \"position\": {\"region\": {\"dc\": \"region_dc\", \"az\": \"region_az\"}}}|\n",
+       "+--------------+-------------------------------------------------------------------------------------------------------------------+\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- specific property as a DataFrame ---\n",
+    "# Filter the SHOW TBLPROPERTIES result down to just the property we care about.\n",
+    "spark.sql(f\"SHOW TBLPROPERTIES {table}\").filter(\"key = 'custom-details'\").show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c492d2af",
+   "metadata": {},
+   "source": [
+    "### As a Python dict (handy for programmatic checks)\n",
+    "\n",
+    "Collect all rows into a `{key: value}` dict. Because the value was stored as JSON, `json.loads(...)` turns it back into a native Python object."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d6bb11d5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'owner': 'the_owner', 'labels': ['test', 'extra'], 'position': {'region': {'dc': 'region_dc', 'az': 'region_az'}}}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- As a Python dict (handy for programmatic checks) ---\n",
+    "# Materialize all properties into a plain {key: value} dict.\n",
+    "props = {r[\"key\"]: r[\"value\"] for r in spark.sql(f\"SHOW TBLPROPERTIES {table}\").collect()}\n",
+    "# The stored value is a JSON string -> json.loads() turns it back into a dict.\n",
+    "print(json.loads(props.get(\"custom-details\")))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6afd1291",
+   "metadata": {},
+   "source": [
+    "### A single property's raw value\n",
+    "\n",
+    "`SHOW TBLPROPERTIES <table> ('<key>')` returns just that one property. Note the value comes back as a **`str`** (the raw stored text), so parse it with `json.loads(...)` if you need the structured form."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a337845e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<class 'str'>: {\"owner\": \"the_owner\", \"labels\": [\"test\", \"extra\"], \"position\": {\"region\": {\"dc\": \"region_dc\", \"az\": \"region_az\"}}}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# --- a single property's value ---\n",
+    "# SHOW TBLPROPERTIES <table> ('<key>') returns only that one property.\n",
+    "prop_val = spark.sql(f\"SHOW TBLPROPERTIES {table} ('custom-details')\").collect()[0][\"value\"]\n",
+    "# The value is a str (not a dict) -- parse with json.loads if you need the object.\n",
+    "print(f\"{type(prop_val)}: {prop_val}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "076ced47",
+   "metadata": {},
+   "source": [
+    "## 5. Overwrite an existing property\n",
+    "\n",
+    "Running `SET TBLPROPERTIES` again with the **same key** simply overwrites the previous value — there is no separate \"update\" statement."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "1bb96a76",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Re-running SET TBLPROPERTIES with the same key OVERWRITES the previous value.\n",
+    "spark.sql(f\"\"\"\n",
+    "    ALTER TABLE {table}\n",
+    "    SET TBLPROPERTIES (\n",
+    "        'custom-details' = 'overridden-value'\n",
+    "    )\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "50be1990",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+--------------+----------------+\n",
+       "|key           |value           |\n",
+       "+--------------+----------------+\n",
+       "|custom-details|overridden-value|\n",
+       "+--------------+----------------+\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Confirm the value was replaced (now a plain string, no longer JSON).\n",
+    "spark.sql(f\"SHOW TBLPROPERTIES {table}\").filter(\"key = 'custom-details'\").show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1e9c004e",
+   "metadata": {},
+   "source": [
+    "## 6. Remove a property\n",
+    "\n",
+    "`UNSET TBLPROPERTIES` deletes the property. Adding `IF EXISTS` keeps the cell idempotent — it won't error if the key has already been removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "48ecc632",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# UNSET ... IF EXISTS removes the property; IF EXISTS avoids an error\n",
+    "# if the key is already gone (keeps the cell idempotent).\n",
+    "spark.sql(f\"ALTER TABLE {table} UNSET TBLPROPERTIES IF EXISTS ('custom-details')\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "3cf53a6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "+---+-----+\n",
+       "|key|value|\n",
+       "+---+-----+\n",
+       "+---+-----+\n",
+       "\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Verify the property is gone -- the filtered result is now empty.\n",
+    "spark.sql(f\"SHOW TBLPROPERTIES {table}\").filter(\"key = 'custom-details'\").show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13c97408",
+   "metadata": {},
+   "source": [
+    "## Recap & cleanup\n",
+    "\n",
+    "- **Set / update:** `ALTER TABLE <t> SET TBLPROPERTIES ('k' = 'v')` (re-running overwrites).\n",
+    "- **Read:** `SHOW TBLPROPERTIES <t>` (all) or `SHOW TBLPROPERTIES <t> ('k')` (one).\n",
+    "- **Remove:** `ALTER TABLE <t> UNSET TBLPROPERTIES IF EXISTS ('k')`.\n",
+    "- **Values are strings** — serialize structured data with `json.dumps` and read it back with `json.loads`.\n",
+    "\n",
+    "To clean up the demo table when you're done:\n",
+    "\n",
+    "```python\n",
+    "spark.sql(f\"DROP TABLE IF EXISTS {table}\")\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/data-engineering/miscellaneous/working_with_table_properties.ipynb
+++ b/data-engineering/miscellaneous/working_with_table_properties.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "59007b0c",
    "metadata": {},
    "source": [
     "# Working with Spark SQL Table Properties\n",
@@ -25,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1dc03c4d",
    "metadata": {},
    "source": [
     "## 1. Create a demo table\n",
@@ -35,18 +33,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "54276915",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "DataFrame[]"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -60,7 +57,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "392b55da",
    "metadata": {},
    "source": [
     "## 2. Inspect the default properties\n",
@@ -70,11 +66,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "ed13c4af",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "+---------------------------+-------+\n",
@@ -88,8 +84,7 @@
        "\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -102,7 +97,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "967c52af",
    "metadata": {},
    "source": [
     "## 3. Store structured (JSON) metadata in a property\n",
@@ -114,18 +108,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "4a6323c5",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "DataFrame[]"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -154,7 +147,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "053b1e4d",
    "metadata": {},
    "source": [
     "## 4. Read the property back\n",
@@ -164,7 +156,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b16a7cc",
    "metadata": {},
    "source": [
     "### As a DataFrame (filter to one key)"
@@ -172,11 +163,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "1551ef24",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "+--------------+-------------------------------------------------------------------------------------------------------------------+\n",
@@ -187,8 +178,7 @@
        "\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -199,7 +189,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c492d2af",
    "metadata": {},
    "source": [
     "### As a Python dict (handy for programmatic checks)\n",
@@ -209,18 +198,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "d6bb11d5",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "{'owner': 'the_owner', 'labels': ['test', 'extra'], 'position': {'region': {'dc': 'region_dc', 'az': 'region_az'}}}\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -233,7 +221,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6afd1291",
    "metadata": {},
    "source": [
     "### A single property's raw value\n",
@@ -243,18 +230,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "a337845e",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "<class 'str'>: {\"owner\": \"the_owner\", \"labels\": [\"test\", \"extra\"], \"position\": {\"region\": {\"dc\": \"region_dc\", \"az\": \"region_az\"}}}\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -267,7 +253,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "076ced47",
    "metadata": {},
    "source": [
     "## 5. Overwrite an existing property\n",
@@ -277,18 +262,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "id": "1bb96a76",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "DataFrame[]"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -303,11 +287,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "50be1990",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "+--------------+----------------+\n",
@@ -318,8 +302,7 @@
        "\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -329,7 +312,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e9c004e",
    "metadata": {},
    "source": [
     "## 6. Remove a property\n",
@@ -339,18 +321,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "48ecc632",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "DataFrame[]"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -361,11 +342,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "3cf53a6c",
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
       "text/plain": [
        "+---+-----+\n",
@@ -375,8 +356,7 @@
        "\n"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     }
    ],
    "source": [
@@ -386,7 +366,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "13c97408",
    "metadata": {},
    "source": [
     "## Recap & cleanup\n",
@@ -407,12 +386,22 @@
  "metadata": {
   "kernelspec": {
    "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 5
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
## Summary

Adds a new `data-engineering/miscellaneous/` sample demonstrating how to manage **Spark SQL table properties** on the AIDP lakehouse (managed Delta table).

Table properties are arbitrary `key = value` metadata attached to a table — a convenient place to record ownership, classification labels, lineage hints, or other governance metadata so the context travels with the data.

The annotated notebook walks through the full lifecycle:

1. Create a demo table.
2. Inspect engine-managed default properties (`SHOW TBLPROPERTIES`).
3. Store **structured (JSON) metadata** in a property — values are strings, so `json.dumps` → string → `json.loads`.
4. Read a property back — as a DataFrame, a Python dict, and a single raw value.
5. Overwrite an existing property (`SET TBLPROPERTIES`).
6. Remove a property (`UNSET TBLPROPERTIES IF EXISTS`).

## Contents

- `data-engineering/miscellaneous/working_with_table_properties.ipynb` — annotated notebook with markdown section headers, inline comments, and captured outputs.
- `data-engineering/miscellaneous/README.md` — short overview of the operations and prerequisites.
- `README.md` — adds the sample to the Sample Catalog under a new **Miscellaneous** subsection (per `CONTRIBUTING.md`).

## Notes

- The notebook code is unchanged from a real AIDP run; only explanatory markdown cells and comments were added, so the captured cell outputs remain faithful to actual execution.
- Uses only placeholder/demo values (e.g. `default.default.test_table_prop`, `the_owner`) — no credentials, OCIDs, or environment-specific identifiers.
- The notebook is `nbformat` 4.4 with a full `kernelspec`/`language_info` (incl. `codemirror_mode`), matching the repo's other sample notebooks so cells render at normal size on GitHub.
- All commits include the OCA `Signed-off-by` trailer.