### PR TITLE
Add sample: APEX chat with inline charts over OAC (MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Python tool packages that extend agent flows with user-authored capabilities. Up
 | Sample | Description |
 |---|---|
 | [AIDP Agent Chat — Web UI](ai/aidp_chat_client/web_ui/README.md) | Browser chat UI for any deployed AIDP agent: a Flask proxy that handles OCI request signing plus a single-page HTML frontend. Includes a one-command deploy script for OCI Container Instances. |
+| [APEX Chat with Inline Charts (over OAC via MCP)](ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/) | Render an AIDP agent's answers as inline charts inside an Oracle APEX chat, driven by an agent-agnostic chart marker that both low-code and high-code agents emit. |
 
 #### Code-First Agent Flows
 

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/README.md
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/README.md
@@ -1,0 +1,246 @@
+# APEX Chat with Inline Charts (over OAC via MCP)
+
+Render an AIDP agent's answers as **inline charts inside an Oracle APEX chat**.
+When the agent replies with a category-to-number breakdown (e.g. "sales by
+region"), a horizontal bar, pie, vertical bar, line, donut, pyramid, or funnel
+chart appears directly beneath the answer in the chat transcript.
+
+The trick is a small, agent-agnostic **chart marker**: the agent appends a
+hidden marker to its reply, and a bit of JavaScript in the APEX chat region
+turns that marker into a chart. Because the marker is the same regardless of how
+the agent is built, **a low-code AIDP agent and a high-code agent both work with
+the identical front-end.**
+
+## Contents
+
+- [What this sample is (and isn't)](#what-this-sample-is-and-isnt)
+- [Features](#features)
+- [How it works](#how-it-works)
+- [Prerequisites](#prerequisites)
+- [Step-by-step](#step-by-step)
+  - [Step 1 - Teach your agent to emit the chart marker](#step-1---teach-your-agent-to-emit-the-chart-marker)
+  - [Step 2 - Upload the renderer into your APEX app](#step-2---upload-the-renderer-into-your-apex-app)
+  - [Step 3 - Call the renderer when an answer arrives](#step-3---call-the-renderer-when-an-answer-arrives)
+  - [Step 4 - Connect your APEX chat to the deployed agent endpoint](#step-4---connect-your-apex-chat-to-the-deployed-agent-endpoint)
+- [The chart marker](#the-chart-marker)
+- [Troubleshooting](#troubleshooting)
+- [Security notes](#security-notes)
+- [Folder layout](#folder-layout)
+
+## What this sample is (and isn't)
+
+This sample is **only the chart layer** - the two chart-specific pieces you add
+on top of a working agent chat. It is **not** a full chat application.
+
+To get an inline chart in APEX, you need all four of these:
+
+| # | What you need | Provided by |
+|---|---------------|-------------|
+| 1 | A deployed AIDP agent connected to your data (low-code or high-code) | You |
+| 2 | An APEX chat region that sends messages to the agent and shows the reply | You - or build one with the sibling samples below |
+| 3 | The agent taught to emit the chart marker | **This sample** → [`agent/`](agent/) |
+| 4 | APEX code that reads the marker and draws the chart | **This sample** → [`apex/render_chart_marker.js`](apex/render_chart_marker.js) |
+
+Items 1-2 are generic chat plumbing, already covered by
+`../invoke-agent-flows-from-apex/` (calling an agent flow from APEX) and
+`../../../aidp_chat_client/` (a standalone chat client). **Bring your own chat
+surface; this sample adds the charts to it** (items 3-4). The renderer is
+self-contained - it loads Chart.js on demand and needs no extra CSS.
+
+## Features
+
+- Inline charts rendered in the chat transcript, right under each answer.
+- Seven chart types from one marker: `hbar`, `pie`, `bar`, `line`, `donut`, `pyramid`, `funnel`.
+- **Agent-agnostic:** low-code (pasted instructions) and high-code (a prompt rule) emit the identical marker.
+- No build step: one plain JS file; Chart.js is fetched on demand only for the donut.
+
+## How it works
+
+```mermaid
+flowchart TD
+    U(["User"]) -->|"1 - asks a question"| CHAT["APEX chat region"]
+    CHAT -->|"2 - POST to the agent endpoint"| AGENT{{"AIDP agent<br/>(low-code or high-code)"}}
+    AGENT <-->|"3 - query data over MCP"| DATA[("Data source<br/>e.g. OAC")]
+    AGENT -->|"4 - reply carries a hidden CHART marker"| CHAT
+    CHAT -->|"5 - raw reply text"| RENDER["render_chart_marker.js"]
+    RENDER -->|"6 - chart drawn inline"| U
+```
+
+This sample provides two of those pieces: the **chart rule** the agent follows
+([`agent/`](agent/)), which drives step 4, and the **renderer**
+([`apex/render_chart_marker.js`](apex/render_chart_marker.js)) at steps 5-6. The
+chat region, the agent, and the data source are yours.
+
+The agent carries the chart in its reply as a hidden HTML comment, so it never
+shows in the chat bubble:
+
+```
+Here is sales by region:
+| Region | Sales |
+| North  |  120  |  ...
+<!--CHART:{"type":"hbar","title":"Sales by region","data":[...]}-->
+```
+
+The full marker format and type list are in [The chart marker](#the-chart-marker) below.
+
+## Prerequisites
+
+1. An **AIDP agent** connected to your data, deployed, and reachable from APEX. It can be **low-code or high-code** (this sample supports both).
+2. An **Oracle APEX** workspace and app with a **chat region** that sends the user's message to the agent and shows the agent's reply.
+3. A data source your agent can query. This sample was built against **Oracle Analytics Cloud (OAC) over MCP**, but the chart layer does not care where the numbers come from.
+
+If you do not yet have #1 and #2, set those up first using the sibling samples
+linked above, then come back here to add charts.
+
+## Step-by-step
+
+### Step 1 - Teach your agent to emit the chart marker
+
+Pick the path that matches how your agent is built. Both produce the **same**
+marker, so you only ever do one of these.
+
+**Low-code agent**
+1. Open your agent in the AIDP Workbench and edit its **Instructions**.
+2. Copy the chart-rule block from [`agent/low-code-instructions.md`](agent/low-code-instructions.md) and paste it **after** your existing data/query instructions.
+3. Save.
+
+**High-code agent**
+1. Open [`agent/high-code-marker-snippet.py`](agent/high-code-marker-snippet.py).
+2. Copy the `CHART_BLOCK_RULE` string and add it to your agent's prompt rules (for the AIDP Python SDK this is `prompt.extra_rules`; for a raw system prompt, append it to the system prompt text). The file shows both.
+3. Your agent's own setup and auth stay as they are - if you connect to OAC over MCP, the wiring example is `../../code-first/mcp-examples/single-agent-mcp-session-variables.py`.
+
+**Verify Step 1:** ask the agent *"break down sales by region"*. The raw reply
+should end with a line like:
+```
+<!--CHART:{"type":"hbar","title":"Sales by region","data":[{"label":"North","value":120}, ...]}-->
+```
+
+### Step 2 - Upload the renderer into your APEX app
+
+These steps **add the chart renderer to an existing chat region** - they do not
+create the chat region itself (that is the prerequisite above). Do this in
+**App Builder** on the app that has your chat page:
+
+1. Open your app in **App Builder**.
+2. Go to **Shared Components** &rarr; under *Files*, click **Static Application Files**.
+3. Click **Create File** (or **Upload File**), select [`apex/render_chart_marker.js`](apex/render_chart_marker.js), and click **Create**. APEX now serves it at `#APP_FILES#render_chart_marker.js`.
+4. Open the page that has your chat region in **Page Designer**.
+5. In the Rendering tree, select the **page root** node (the very top), then in the Property Editor open the **JavaScript** group.
+6. In **File URLs**, add this line:
+   ```
+   #APP_FILES#render_chart_marker.js
+   ```
+7. Click **Save**.
+
+This loads the renderer and defines a global `ACPChart` object (methods
+`renderAfter()`, `renderInto()`, `scan()`). Nothing draws yet - Step 3 calls it.
+
+> Prefer not to upload a file? Instead of steps 2-3, paste the entire contents
+> of `render_chart_marker.js` into the region's **JavaScript &rarr; Function and
+> Global Variable Declaration**.
+
+### Step 3 - Call the renderer when an answer arrives
+
+The renderer needs the **raw** agent reply (still containing the marker). Run
+`ACPChart` right after your chat renders an assistant answer. The standard APEX
+way, using a Dynamic Action:
+
+1. In Page Designer, add a **Dynamic Action** on your chat region that fires when a new answer appears (for many chat regions that is the region's **After Refresh** event; adapt it to your chat's own event).
+2. Add a **True action &rarr; Execute JavaScript Code** with:
+   ```js
+   // Each assistant answer element should carry data-agent-answer and still
+   // contain the raw marker in its text. Then:
+   ACPChart.scan(document.getElementById('YOUR_CHAT_REGION_STATIC_ID'), '[data-agent-answer]');
+   ```
+3. Click **Save**, then **Run** the page.
+
+If instead your chat region renders each answer itself in JavaScript, just call
+`ACPChart.renderAfter(answerEl, rawText)` as you append the answer - where
+`answerEl` is the answer's element and `rawText` is the raw reply (with the
+marker).
+
+> **Gotcha - the marker must reach the browser.** The renderer can only draw
+> what it can see. If your region strips HTML comments or only stores a
+> "cleaned" reply, keep the raw reply available to the client (e.g. in the
+> element's text or a data attribute) so the marker survives to Step 3.
+
+### Step 4 - Connect your APEX chat to the deployed agent endpoint
+
+This is your existing chat plumbing; the chart layer rides on top of it. If you
+still need to wire it:
+
+1. In the AIDP Workbench, open your **deployed** agent and go to its **Details**.
+2. Copy the agent's **endpoint / invocation URL**.
+3. Configure your APEX chat region to POST the user's message to that endpoint
+   and display the reply. See `../invoke-agent-flows-from-apex/` for a full
+   worked example of calling an agent from APEX, and `../../../aidp_chat_client/`
+   for a standalone chat client.
+
+## The chart marker
+
+The agent appends **one** HTML comment on its own final line, after the prose.
+Because it is a comment it never shows in the bubble; the renderer reads it from
+the raw reply:
+
+```
+<!--CHART:{"type":"hbar","title":"Sales by region","data":[{"label":"North","value":120},{"label":"South","value":90}]}-->
+```
+
+**Fields**
+
+| Field   | Type   | Notes |
+|---------|--------|-------|
+| `type`  | string | One of `hbar`, `pie`, `bar`, `line`, `donut`, `pyramid`, `funnel` (lowercase). |
+| `title` | string | Short chart title shown above the chart. |
+| `data`  | array  | One object per category: `{ "label": "<category>", "value": <number> }`. |
+
+`value` is a plain number (no quotes, thousands separators, or currency); include
+every row you listed. Valid JSON between `CHART:` and `-->` - no code fences, no
+second comment, nothing after `-->`.
+
+**Types**
+
+| `type` | Renders as | Good for |
+|--------|------------|----------|
+| `hbar` | Horizontal bar (default, auto) | Rankings and comparisons; long labels. |
+| `pie` | Pie (auto for composition) | Share of a whole. |
+| `bar` | Vertical bar | Comparisons where a vertical layout reads better. |
+| `line` | Line (auto for trends over time) | A value across an ordered sequence. |
+| `donut` | Donut with a centre total | Composition with the total called out (name it). |
+| `pyramid` | Pyramid | Ranked stages / hierarchy. |
+| `funnel` | Funnel | Stages that shrink (e.g. a pipeline). |
+
+The agent **auto-picks only `hbar`, `pie`, or `line`**; `bar`, `donut`,
+`pyramid`, and `funnel` appear only when the user names them. The full
+selection rule the agent follows lives in the [`agent/`](agent/) files.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| No chart appears | The marker never reached the browser | Confirm the raw reply (with the `<!--CHART...-->` comment) is what Step 3 reads; don't strip comments server-side. |
+| No chart, but the raw reply has a marker | Renderer not loaded, or not called | Confirm `render_chart_marker.js` is on the page (Step 2) and `renderAfter`/`scan` runs after the answer renders (Step 3). |
+| Donut shows as a full pie / is blank | Chart.js failed to load | Check the network request to the pinned Chart.js URL; the CDN host must be reachable. All other types use JET and need no CDN. |
+| Chart renders twice | `scan()` ran more than once on the same answer | The `data-acp-charted` guard prevents this per element; make sure you reuse the same element, not a re-created one. |
+| Agent shows a table but no marker | The chart rule isn't in effect | Re-check Step 1 - the rule must be pasted/added after the agent's other instructions, and saved/redeployed. |
+
+## Security notes
+
+- This sample contains **no secrets and no environment-specific values** - all example data is invented. Keep it that way in your fork.
+- The agent endpoint URL, any credentials, and your data connection live in your
+  APEX app and agent config, **not** in these files.
+- The renderer sanitizes nothing itself; it only reads a marker and draws a
+  chart. Keep using your chat region's existing HTML sanitization for the answer
+  text (this sample assumes markdown is rendered and sanitized upstream).
+
+## Folder layout
+
+```
+apex-chat-charts-over-oac-mcp/
+├── README.md                         <- you are here (the guide + the marker spec)
+├── agent/
+│   ├── low-code-instructions.md      <- paste into a low-code agent's Instructions
+│   └── high-code-marker-snippet.py   <- add the rule to a high-code agent's prompt
+└── apex/
+    └── render_chart_marker.js        <- paste into APEX; turns the marker into a chart
+```

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/high-code-marker-snippet.py
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/high-code-marker-snippet.py
@@ -1,0 +1,88 @@
+"""
+High-code agent: emit the chart marker.
+
+This snippet is intentionally NARROW. It shows only the reusable piece: the
+rule that makes a high-code agent append the chart marker, so its answers get
+inline charts in the APEX chat region (see the marker spec in ../README.md).
+
+It is deliberately NOT a full agent. Your agent's setup - the LLM, the MCP
+connection to your data source, and authentication - is your own. If you are
+connecting to Oracle Analytics Cloud (OAC) over MCP with per-user auth, the
+repo already has a complete working example; reference it rather than copying
+auth code around:
+
+    ../../../code-first/mcp-examples/single-agent-mcp-session-variables.py
+
+The only thing this file adds on top of that: the CHART_BLOCK_RULE below, added
+to your agent's prompt rules. The marker it produces is IDENTICAL to the one a
+low-code agent emits (low-code-instructions.md), so the same APEX front-end
+renders both.
+"""
+
+# ---------------------------------------------------------------------------
+# 1) YOUR AGENT + AUTH SETUP GOES HERE.
+#    Build your agent, connect to your data source (e.g. OAC over MCP), and
+#    wire up auth. For an OAC-MCP + per-user-auth starting point, see:
+#    ../../../code-first/mcp-examples/single-agent-mcp-session-variables.py
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# 2) THE CHART RULE. Add this to your agent's prompt rules (for the AIDP
+#    Python SDK this is prompt.extra_rules; for a raw system prompt, append it
+#    to the system prompt text). It is the same rule a low-code agent uses.
+# ---------------------------------------------------------------------------
+CHART_BLOCK_RULE = """
+CHART BLOCK - MANDATORY FORMATTING RULE.
+If your answer contains ANY breakdown of a category by a number (a per-category
+list, a table with a category column and a number column, "X by Y", counts or
+totals per group, or a ranking), you MUST append the chart block. It is not
+optional: an answer that shows a breakdown but omits the block is incomplete.
+Append the block for the exact rows you listed; the table AND the chart block
+are both required.
+
+FORMAT: on its own final line, AFTER the prose, put the chart JSON inside a
+single HTML comment so it never shows in the chat bubble:
+<!--CHART:{"type":"<type>","title":"<short title>","data":[{"label":"<category>","value":<number>}]}-->
+
+CHOOSING "type" - apply IN ORDER, stop at the first match:
+  1. IF the user names a chart type ("as a bar", "as a donut", "as a
+     pyramid / funnel", or any explicit type) use EXACTLY that type. The
+     user's choice wins.
+  2. ELSE if the question is about composition / share / proportion / mix /
+     percentage / split, use "pie".
+  3. ELSE if the answer is a trend over an ordered sequence (over time,
+     "by month / quarter / year", "trend"), use "line".
+  4. ELSE (counts, totals, rankings, comparisons) use "hbar". Default.
+
+"type" is EXACTLY one of: hbar, pie, bar, line, donut, pyramid, funnel (lowercase).
+The data shape is identical for every type ({label,value}); only "type" changes.
+Auto-selection is only ever hbar, pie, or line. NEVER auto-pick bar / donut /
+pyramid / funnel; use those ONLY when the user names them.
+
+Rules: one object per category in "data" (include EVERY row you listed);
+"value" is a plain number (no quotes, no thousands separators). No code fences,
+no second comment, nothing after the closing -->. NEVER emit a chart of
+made-up values. Only omit the block for a single value, a metadata answer, or
+plain prose with no category-to-number breakdown.
+"""
+
+
+# ---------------------------------------------------------------------------
+# 3) EXAMPLE of attaching the rule.
+#    Below is illustrative only - adapt it to however your agent is defined.
+# ---------------------------------------------------------------------------
+def build_prompt_rules(existing_rules=None):
+    """Return the agent's prompt rules with the chart rule appended.
+
+    existing_rules: your agent's current list of prompt rules (e.g. the AIDP
+    SDK's prompt.extra_rules). The chart rule is added last so it layers on top
+    of your data/query instructions.
+    """
+    rules = list(existing_rules or [])
+    rules.append(CHART_BLOCK_RULE.strip())
+    return rules
+
+
+# For a plain system-prompt agent, you would instead do:
+#     system_prompt = your_system_prompt + "\n\n" + CHART_BLOCK_RULE

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/low-code-instructions.md
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/low-code-instructions.md
@@ -1,0 +1,66 @@
+# Low-code agent: chart instructions
+
+Paste the block below into a **low-code AIDP agent's Instructions** field. It
+teaches the agent to append the chart marker whenever its answer contains a
+category-to-number breakdown. That marker is what the APEX chat region renders
+inline (see the marker spec in [`../README.md`](../README.md)).
+
+> This file is **only** the chart rule. Your agent still needs its own data
+> instructions - how to find and query your data source (for example, an OAC
+> dataset over MCP). Keep those as-is and add this rule on top. Where this text
+> says "the data you just listed", it means the rows your agent already
+> retrieved and showed; this rule never invents numbers.
+
+---
+
+```
+CHART BLOCK - MANDATORY FORMATTING RULE.
+If your answer contains ANY breakdown of a category by a number (a per-category
+list, a table with a category column and a number column, "X by Y", counts or
+totals per group, or a ranking), you MUST append the chart block. It is not
+optional: an answer that shows a breakdown but omits the block is incomplete.
+Append the block for the exact rows you listed - never skip it because you
+"already showed a table"; the table AND the chart block are both required.
+
+FORMAT: on its own final line, AFTER the prose, put the chart JSON inside a
+single HTML comment so it never shows in the chat bubble:
+<!--CHART:{"type":"<type>","title":"<short title>","data":[{"label":"<category>","value":<number>}]}-->
+
+CHOOSING "type" - apply IN ORDER, stop at the first match:
+  1. IF the user names a chart type ("as a bar", "as a donut", "as a
+     pyramid / funnel", or any explicit type) use EXACTLY that type. The
+     user's choice always wins.
+  2. ELSE if the question is about composition / share / proportion / mix /
+     percentage / split, use "pie".
+  3. ELSE if the answer is a trend over an ordered sequence (over time,
+     "by month / quarter / year", "trend", "over the last N ..."), use "line".
+  4. ELSE (counts, totals, rankings, comparisons: "break down", "by", "per",
+     "each", "how many", "top", "most") use "hbar". Default; when in doubt, "hbar".
+
+"type" is EXACTLY one of: hbar, pie, bar, line, donut, pyramid, funnel (lowercase).
+The data shape is identical for every type ({label,value}); only "type" changes.
+Auto-selection is only ever hbar, pie, or line. NEVER auto-pick bar / donut /
+pyramid / funnel; use those ONLY when the user explicitly names them (rule 1).
+
+Rules: one object per category in "data" (include EVERY row you listed);
+"value" is a plain number (no quotes, no thousands separators). Do NOT wrap the
+block in code fences, do NOT emit a second comment, put NOTHING after the
+closing -->. NEVER emit a chart of made-up values - if you could not retrieve
+the data, say so plainly and omit the block. Only omit the block when the
+answer is a single value, a metadata answer, or plain prose with no
+category-to-number breakdown.
+```
+
+---
+
+## Quick check
+
+Ask the agent something like *"break down sales by region"*. The reply should
+end with a line such as:
+
+```
+<!--CHART:{"type":"hbar","title":"Sales by region","data":[{"label":"North","value":120},{"label":"South","value":90},{"label":"East","value":140},{"label":"West","value":75}]}-->
+```
+
+If you see that line in the raw reply, the APEX region will turn it into an
+inline chart.

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
@@ -34,8 +34,11 @@
   // Categorical palette. Replace with your own theme colours if you like.
   var PALETTE = ["#4f7fa8", "#5a9e6f", "#a3924e", "#b5544a", "#8a6d9e", "#6b8fb5", "#7cae8a", "#c98a3a"];
 
-  // Chart.js is fetched only for the donut. Pin the version you have vetted.
+  // Chart.js is fetched only for the donut. Pin the version you have vetted,
+  // and keep the SRI hash in sync with it (recompute when bumping the version:
+  //   curl -sL <url> | openssl dgst -sha384 -binary | openssl base64 -A ).
   var CHARTJS_URL = "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js";
+  var CHARTJS_SRI = "sha384-dug+JxfBvklEQdJ4AYuBBAIScUz0bVN73xpy273gcAwHjb3qI0fXmuYNaNfdyYJG";
 
   // Map the marker "type" to an oj-chart config. (donut is handled by Chart.js;
   // the "donut" branch here is only a safety fallback to a plain pie.)
@@ -65,6 +68,11 @@
       var restore = function () { window.define = savedDefine; };
       var s = document.createElement("script");
       s.src = CHARTJS_URL; s.async = true;
+      // Subresource Integrity: the browser refuses to run the script if the
+      // CDN response doesn't match the pinned hash (defense against a
+      // compromised or MITM'd CDN). crossorigin is required for SRI checks.
+      s.integrity = CHARTJS_SRI;
+      s.crossOrigin = "anonymous";
       s.onload  = function () { restore(); resolve(window.Chart); };
       s.onerror = function () { restore(); reject(new Error("Chart.js failed to load")); };
       document.head.appendChild(s);
@@ -180,7 +188,10 @@
 
   // Build the chart card element from a parsed marker spec. Returns the card, or null.
   function buildCard(spec) {
-    if (!spec || !spec.data || !spec.data.length) return null;
+    // data must be a real array — a malformed marker (e.g. "data":"...") would
+    // otherwise pass a truthiness check and throw inside .map(), and that
+    // exception would surface in the CALLER's dynamic action / observer.
+    if (!spec || !Array.isArray(spec.data) || !spec.data.length) return null;
     var rawType = String(spec.type || "hbar").toLowerCase();
 
     var card = document.createElement("div");

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
@@ -1,0 +1,283 @@
+/*
+ * render_chart_marker.js
+ * ---------------------------------------------------------------------------
+ * Renders an inline chart directly beneath an agent's answer inside an Oracle
+ * APEX chat region, driven by a hidden marker the agent appends to its reply:
+ *
+ *   <!--CHART:{"type":"hbar","title":"Sales by region",
+ *              "data":[{"label":"North","value":120},{"label":"South","value":90}]}-->
+ *
+ * The marker is AGENT-AGNOSTIC: a low-code AIDP agent (via pasted instructions)
+ * and a high-code agent (via a system-prompt rule) emit the IDENTICAL marker,
+ * so this front-end code does not care which one produced the answer.
+ *
+ * Chart types:
+ *   - Oracle JET <oj-chart> renders:  hbar, pie, bar, line, pyramid, funnel
+ *   - Chart.js renders:               donut  (JET oj-chart has no hole/cutout type)
+ *
+ * Dependencies:
+ *   - Oracle JET (ships with APEX) provides <oj-chart>.
+ *   - Chart.js is loaded on demand, and ONLY when a donut is requested.
+ *
+ * Usage (see the README for full wiring):
+ *   - ACPChart.renderAfter(answerEl, answerText)  render a chart after one answer
+ *   - ACPChart.scan(rootEl, answerSelector)       auto-render every answer under root
+ *
+ * Notes:
+ *   - The marker is an HTML comment, so it never shows in the rendered bubble.
+ *   - All example data below is invented; wire the marker to your own dataset.
+ * ---------------------------------------------------------------------------
+ */
+(function (window, document) {
+  "use strict";
+
+  // Categorical palette. Replace with your own theme colours if you like.
+  var PALETTE = ["#4f7fa8", "#5a9e6f", "#a3924e", "#b5544a", "#8a6d9e", "#6b8fb5", "#7cae8a", "#c98a3a"];
+
+  // Chart.js is fetched only for the donut. Pin the version you have vetted.
+  var CHARTJS_URL = "https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.js";
+
+  // Map the marker "type" to an oj-chart config. (donut is handled by Chart.js;
+  // the "donut" branch here is only a safety fallback to a plain pie.)
+  function chartType(t) {
+    switch (String(t || "hbar").toLowerCase()) {
+      case "hbar":    return { type: "bar", horizontal: true };
+      case "pie":     return { type: "pie" };
+      case "bar":     return { type: "bar" };
+      case "line":    return { type: "line" };
+      case "donut":   return { type: "pie" };
+      case "pyramid": return { type: "pyramid" };
+      case "funnel":  return { type: "funnel" };
+      default:        return { type: "bar", horizontal: true };
+    }
+  }
+
+  // Load Chart.js once and reuse the same promise for every later donut.
+  function loadChartJs() {
+    if (window.__acpChartJsPromise) return window.__acpChartJsPromise;
+    window.__acpChartJsPromise = new Promise(function (resolve, reject) {
+      if (window.Chart) { resolve(window.Chart); return; }
+      // APEX ships RequireJS, so Chart.js's UMD wrapper would register as an AMD
+      // module instead of setting window.Chart. Hide define() during the load so
+      // the UMD falls back to the global assignment, then restore define().
+      var savedDefine = window.define;
+      window.define = undefined;
+      var restore = function () { window.define = savedDefine; };
+      var s = document.createElement("script");
+      s.src = CHARTJS_URL; s.async = true;
+      s.onload  = function () { restore(); resolve(window.Chart); };
+      s.onerror = function () { restore(); reject(new Error("Chart.js failed to load")); };
+      document.head.appendChild(s);
+    });
+    return window.__acpChartJsPromise;
+  }
+
+  // Pick a readable label colour (dark or white) for a given slice colour.
+  function textOn(hex) {
+    var h = String(hex).replace("#", "");
+    var r = parseInt(h.substr(0, 2), 16), g = parseInt(h.substr(2, 2), 16), b = parseInt(h.substr(4, 2), 16);
+    return ((0.299 * r + 0.587 * g + 0.114 * b) / 255) > 0.6 ? "#25303b" : "#ffffff";
+  }
+
+  // Draw a donut WITH a real hole using Chart.js, into the given card element.
+  function drawDonut(card, spec) {
+    var wrap = document.createElement("div");
+    wrap.style.cssText = "position:relative;width:100%;height:340px;"; // fixed-height box so maintainAspectRatio:false sizes correctly
+    var canvas = document.createElement("canvas");
+    wrap.appendChild(canvas);
+    card.appendChild(wrap);
+
+    loadChartJs().then(function (Chart) {
+      var labels = spec.data.map(function (d) { return String(d.label); });
+      var values = spec.data.map(function (d) { return Number(d.value); });
+      var colors = spec.data.map(function (d, i) { return PALETTE[i % PALETTE.length]; });
+      var total  = values.reduce(function (a, b) { return a + (b || 0); }, 0);
+
+      // Draw each slice's % on the ring (best practice for pie/donut).
+      var slicePct = {
+        id: "acpSlicePct",
+        afterDraw: function (chart) {
+          var meta = chart.getDatasetMeta(0);
+          if (!meta || !meta.data) return;
+          var visTotal = values.reduce(function (a, b, j) {
+            return a + ((chart.getDataVisibility && !chart.getDataVisibility(j)) ? 0 : (Number(b) || 0));
+          }, 0);
+          if (!visTotal) return;
+          var c = chart.ctx; c.save();
+          c.textAlign = "center"; c.textBaseline = "middle";
+          c.font = "600 12px 'Oracle Sans', sans-serif";
+          meta.data.forEach(function (arc, i) {
+            if (chart.getDataVisibility && !chart.getDataVisibility(i)) return; // skip hidden slices
+            var pct = Math.round(((Number(values[i]) || 0) / visTotal) * 1000) / 10;
+            if (pct < 4) return;                                               // skip slivers (no room for a label)
+            var mid = (arc.startAngle + arc.endAngle) / 2;
+            var r = (arc.innerRadius + arc.outerRadius) / 2;
+            c.fillStyle = textOn(colors[i]);
+            c.fillText(pct + "%", arc.x + Math.cos(mid) * r, arc.y + Math.sin(mid) * r);
+          });
+          c.restore();
+        }
+      };
+
+      // Draw the total in the donut hole (that empty centre is meant for a summary).
+      var centerTotal = {
+        id: "acpCenterTotal",
+        afterDraw: function (chart) {
+          var meta = chart.getDatasetMeta(0); var el = meta && meta.data && meta.data[0];
+          if (!el) return;
+          var c = chart.ctx; c.save();
+          c.textAlign = "center"; c.textBaseline = "middle";
+          c.fillStyle = "#25303b"; c.font = "600 22px 'Oracle Sans', sans-serif";
+          c.fillText(String(total), el.x, el.y - 8);
+          c.fillStyle = "#7a8794"; c.font = "400 11px 'Oracle Sans', sans-serif";
+          c.fillText("Total", el.x, el.y + 12);
+          c.restore();
+        }
+      };
+
+      new Chart(canvas, {
+        type: "doughnut",
+        data: { labels: labels, datasets: [{ data: values, backgroundColor: colors, borderColor: "#fff", borderWidth: 2 }] },
+        options: {
+          responsive: true, maintainAspectRatio: false,
+          cutout: "58%",                                          // hole big enough to hold the total
+          plugins: {
+            legend: {
+              position: "right",
+              labels: {
+                boxWidth: 12, font: { size: 12 },
+                // when a slice is toggled off, show its swatch as an empty outline
+                generateLabels: function (chart) {
+                  var items;
+                  try {
+                    var o = Chart.overrides && Chart.overrides.doughnut;
+                    var gen = (o && o.plugins && o.plugins.legend && o.plugins.legend.labels && o.plugins.legend.labels.generateLabels)
+                           || Chart.defaults.plugins.legend.labels.generateLabels;
+                    items = gen(chart);
+                  } catch (e) { items = []; }
+                  items.forEach(function (it) {
+                    if (it.hidden) { it.fillStyle = "#ffffff"; it.strokeStyle = "#c9ced4"; it.lineWidth = 1; }
+                  });
+                  return items;
+                }
+              }
+            },
+            tooltip: {
+              callbacks: {
+                label: function (ctx) {                            // hover shows e.g. "North: 120 (34%)"
+                  var v = Number(ctx.parsed) || 0;
+                  var pct = total ? Math.round((v / total) * 1000) / 10 : 0;
+                  return ctx.label + ": " + v + " (" + pct + "%)";
+                }
+              }
+            }
+          }
+        },
+        plugins: [centerTotal, slicePct]
+      });
+    }).catch(function () { /* Chart.js unavailable: leave the titled card, never break the chat */ });
+  }
+
+  // Build the chart card element from a parsed marker spec. Returns the card, or null.
+  function buildCard(spec) {
+    if (!spec || !spec.data || !spec.data.length) return null;
+    var rawType = String(spec.type || "hbar").toLowerCase();
+
+    var card = document.createElement("div");
+    card.className = "acp-chart";
+    card.style.cssText = "background:#fff;border:1px solid #e3e6ea;border-radius:12px;padding:12px 16px;margin:8px 0 4px;width:100%;box-sizing:border-box;";
+    if (spec.title) {
+      var h = document.createElement("div");
+      h.textContent = spec.title;
+      h.style.cssText = "font-size:13px;font-weight:600;color:#25303b;margin-bottom:8px;";
+      card.appendChild(h);
+    }
+
+    // DONUT: JET oj-chart has no donut/hole type -> draw with Chart.js.
+    if (rawType === "donut") { drawDonut(card, spec); return card; }
+
+    // ALL OTHER TYPES: JET oj-chart.
+    var cfg = chartType(rawType);
+    // JET data shape:
+    //   pie / funnel / pyramid -> ONE series PER category (1 group): distinct colours,
+    //                             per-item legend + click-to-hide.
+    //   bar / hbar             -> one series across N groups, one colour per category.
+    //   line                   -> one series across N groups (markers set below).
+    var nSeries = (cfg.type === "pie" || rawType === "funnel" || rawType === "pyramid");
+    var isLine  = (rawType === "line");
+    var groups, series;
+    if (nSeries) {
+      groups = [spec.title || "Total"];
+      series = spec.data.map(function (d, i) { return { name: String(d.label), items: [Number(d.value)], color: PALETTE[i % PALETTE.length] }; });
+    } else if (isLine) {
+      groups = spec.data.map(function (d) { return String(d.label); });
+      series = [{ name: spec.title || "Value", color: PALETTE[0], lineWidth: 3, items: spec.data.map(function (d) { return Number(d.value); }) }];
+    } else {
+      groups = spec.data.map(function (d) { return String(d.label); });
+      series = [{ name: spec.title || "Value", items: spec.data.map(function (d, i) { return { value: Number(d.value), color: PALETTE[i % PALETTE.length] }; }) }];
+    }
+
+    var chart = document.createElement("oj-chart");
+    chart.setAttribute("type", cfg.type);
+    if (cfg.horizontal) chart.setAttribute("orientation", "horizontal");
+    chart.setAttribute("hover-behavior", "dim");
+    chart.setAttribute("animation-on-display", "auto");
+    if (nSeries) chart.setAttribute("hide-and-show-behavior", "withRescale");
+    if (isLine) {
+      // sparse single line: show a dot at each point, and drop the 1-item legend
+      chart.setAttribute("style-defaults", JSON.stringify({ markerDisplayed: "on" }));
+      chart.setAttribute("legend", JSON.stringify({ rendered: "off" }));
+    }
+    if (!nSeries && !isLine) {
+      // bar / hbar: the bars are already labeled on the axis, so the single-series
+      // legend ("Value") is redundant and misleading - drop it.
+      chart.setAttribute("legend", JSON.stringify({ rendered: "off" }));
+    }
+    chart.style.width = "100%";
+    chart.style.height = "340px";
+    chart.setAttribute("groups", JSON.stringify(groups));
+    chart.setAttribute("series", JSON.stringify(series));
+    card.appendChild(chart);
+    return card;
+  }
+
+  // Parse the first <!--CHART:...--> marker in a block of text -> spec object (or null).
+  function parseMarker(text) {
+    var m = /<!--CHART:([\s\S]*?)-->/.exec(text || "");
+    if (!m) return null;
+    try { return JSON.parse(m[1]); } catch (e) { return null; }
+  }
+
+  window.ACPChart = {
+    // Parse-only helper (exposed for testing).
+    parseMarker: parseMarker,
+
+    // Render a chart INTO a container element from marker text. Returns the card, or null.
+    renderInto: function (container, text) {
+      if (!container) return null;
+      var card = buildCard(parseMarker(text));
+      if (card) container.appendChild(card);
+      return card;
+    },
+
+    // Render a chart immediately AFTER a message element from marker text.
+    // Guards with data-acp-charted so an answer is only charted once.
+    renderAfter: function (rowEl, text) {
+      if (!rowEl || rowEl.getAttribute("data-acp-charted")) return null;
+      var card = buildCard(parseMarker(text));
+      if (card) { rowEl.setAttribute("data-acp-charted", "1"); rowEl.insertAdjacentElement("afterend", card); }
+      return card;
+    },
+
+    // Scan a root element for assistant answers and render each answer's marker.
+    // answerSelector should match each assistant-answer element whose textContent
+    // still contains the raw marker. Default: elements tagged [data-agent-answer].
+    scan: function (root, answerSelector) {
+      if (!root) return;
+      var sel = answerSelector || "[data-agent-answer]";
+      Array.prototype.forEach.call(root.querySelectorAll(sel), function (el) {
+        window.ACPChart.renderAfter(el, el.textContent || "");
+      });
+    }
+  };
+})(window, document);


### PR DESCRIPTION
# Description

Adds a new sample under `ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/` that renders an AIDP agent's answers as inline charts inside an Oracle APEX chat. When the agent's reply contains a category-to-number breakdown, it appends a hidden chart marker; a small JavaScript renderer in the APEX chat region turns that marker into an inline bar / pie / line / donut / pyramid / funnel chart directly beneath the answer.

The marker is agent-agnostic: a low-code AIDP agent (via pasted instructions) and a high-code agent (via a prompt rule) emit the identical marker, so one front-end serves both. This first cut ships the chart layer only (marker contract + agent rule + renderer); it builds on an existing agent chat region. The packaged APEX app export is deferred to a follow-up PR.

Fixes #84

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Validated end-to-end in an AIDP + Oracle APEX + Oracle Analytics Cloud (OAC over MCP) environment:

- [x] A low-code and a high-code agent emit the identical chart marker.
- [x] All seven chart types (hbar, bar, pie, line, donut, pyramid, funnel) render inline beneath the answer.
- [x] Low-code / high-code parity confirmed across all types.

Test Configuration: N/A - this is a documentation/sample contribution, not a firmware/hardware change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
