### PR TITLE
Enhance apex-chat-charts sample: time-axis line + clickable bar legend

### DIFF
--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/README.md
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/README.md
@@ -51,6 +51,8 @@ self-contained - it loads Chart.js on demand and needs no extra CSS.
 
 - Inline charts rendered in the chat transcript, right under each answer.
 - Seven chart types from one marker: `hbar`, `pie`, `bar`, `line`, `donut`, `pyramid`, `funnel`.
+- **Time series on a real date axis:** when the breakdown is by date/period, the answer renders as a line on a chronological time axis. The renderer even upgrades a date-labelled `hbar`/`bar` to a time-axis line, so "count by year" looks right without relying on the model to pick `line`.
+- **Clickable bar legend:** `hbar`/`bar` charts get a per-category colour legend with click-to-hide, while keeping real bars.
 - **Agent-agnostic:** low-code (pasted instructions) and high-code (a prompt rule) emit the identical marker.
 - No build step: one plain JS file; Chart.js is fetched on demand only for the donut.
 
@@ -193,26 +195,36 @@ the raw reply:
 | `type`  | string | One of `hbar`, `pie`, `bar`, `line`, `donut`, `pyramid`, `funnel` (lowercase). |
 | `title` | string | Short chart title shown above the chart. |
 | `data`  | array  | One object per category: `{ "label": "<category>", "value": <number> }`. |
+| `xAxis` | string | **Optional, `line` only.** Set to `"time"` for a time series; then every `label` must be an ISO date (`"YYYY-MM-DD"`) in ascending order, and the chart renders on a real chronological axis. Set to `"category"` to force a plain axis (opt out of the auto time-axis upgrade). |
 
 `value` is a plain number (no quotes, thousands separators, or currency); include
 every row you listed. Valid JSON between `CHART:` and `-->` - no code fences, no
 second comment, nothing after `-->`.
 
+A time-series marker looks like this:
+
+```
+<!--CHART:{"type":"line","xAxis":"time","title":"Invoices by month","data":[{"label":"2026-01-01","value":120},{"label":"2026-02-01","value":150}]}-->
+```
+
 **Types**
 
 | `type` | Renders as | Good for |
 |--------|------------|----------|
-| `hbar` | Horizontal bar (default, auto) | Rankings and comparisons; long labels. |
-| `pie` | Pie (auto for composition) | Share of a whole. |
-| `bar` | Vertical bar | Comparisons where a vertical layout reads better. |
-| `line` | Line (auto for trends over time) | A value across an ordered sequence. |
-| `donut` | Donut with a centre total | Composition with the total called out (name it). |
+| `hbar` | Horizontal bar with a clickable category legend (default, auto) | Rankings and comparisons; long labels. |
+| `donut` | Donut with a centre total (auto for composition) | Share of a whole, total called out. |
+| `line` | Line; on a real time axis when `xAxis:"time"` (auto for date/time breakdowns) | A value across an ordered or time sequence. |
+| `bar` | Vertical bar with a clickable category legend | Comparisons where a vertical layout reads better. |
+| `pie` | Pie | Share of a whole (when explicitly asked). |
 | `pyramid` | Pyramid | Ranked stages / hierarchy. |
 | `funnel` | Funnel | Stages that shrink (e.g. a pipeline). |
 
-The agent **auto-picks only `hbar`, `pie`, or `line`**; `bar`, `donut`,
-`pyramid`, and `funnel` appear only when the user names them. The full
-selection rule the agent follows lives in the [`agent/`](agent/) files.
+The agent **auto-picks only `hbar`, `donut`, or a time-axis `line`**; `bar`,
+`pie`, `pyramid`, and `funnel` appear only when the user names them. Separately,
+the renderer upgrades any date-labelled `hbar`/`bar`/`line` to a time-axis line
+(unless the marker sets `xAxis:"category"`), so a "count by year" reads as a
+trend even if the agent picked `hbar`. The full selection rule the agent follows
+lives in the [`agent/`](agent/) files.
 
 ## Troubleshooting
 
@@ -221,6 +233,7 @@ selection rule the agent follows lives in the [`agent/`](agent/) files.
 | No chart appears | The marker never reached the browser | Confirm the raw reply (with the `<!--CHART...-->` comment) is what Step 3 reads; don't strip comments server-side. |
 | No chart, but the raw reply has a marker | Renderer not loaded, or not called | Confirm `render_chart_marker.js` is on the page (Step 2) and `renderAfter`/`scan` runs after the answer renders (Step 3). |
 | Donut shows as a full pie / is blank | Chart.js failed to load | Check the network request to the pinned Chart.js URL; the CDN host must be reachable. All other types use JET and need no CDN. |
+| A "count by year" renders as a line, not bars | The renderer auto-upgrades date-labelled data to a time-axis line | Expected. To force bars, set `"xAxis":"category"` in the marker (or the agent's rule). |
 | Chart renders twice | `scan()` ran more than once on the same answer | The `data-acp-charted` guard prevents this per element; make sure you reuse the same element, not a re-created one. |
 | Agent shows a table but no marker | The chart rule isn't in effect | Re-check Step 1 - the rule must be pasted/added after the agent's other instructions, and saved/redeployed. |
 

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/README.md
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/README.md
@@ -223,7 +223,9 @@ The agent **auto-picks only `hbar`, `donut`, or a time-axis `line`**; `bar`,
 `pie`, `pyramid`, and `funnel` appear only when the user names them. Separately,
 the renderer upgrades any date-labelled `hbar`/`bar`/`line` to a time-axis line
 (unless the marker sets `xAxis:"category"`), so a "count by year" reads as a
-trend even if the agent picked `hbar`. The full selection rule the agent follows
+trend even if the agent picked `hbar`. Bare 4-digit labels only count as years
+inside 1900–2100, so 4-digit category codes (departments, postal prefixes)
+never trigger the upgrade. The full selection rule the agent follows
 lives in the [`agent/`](agent/) files.
 
 ## Troubleshooting
@@ -232,7 +234,7 @@ lives in the [`agent/`](agent/) files.
 |---------|--------------|-----|
 | No chart appears | The marker never reached the browser | Confirm the raw reply (with the `<!--CHART...-->` comment) is what Step 3 reads; don't strip comments server-side. |
 | No chart, but the raw reply has a marker | Renderer not loaded, or not called | Confirm `render_chart_marker.js` is on the page (Step 2) and `renderAfter`/`scan` runs after the answer renders (Step 3). |
-| Donut shows as a full pie / is blank | Chart.js failed to load | Check the network request to the pinned Chart.js URL; the CDN host must be reachable. All other types use JET and need no CDN. |
+| Donut renders as a plain pie (no centre total) | Chart.js failed to load; the renderer fell back to the JET pie so the chart still shows | Check the network request to the pinned Chart.js URL; the CDN host must be reachable. All other types use JET and need no CDN. |
 | A "count by year" renders as a line, not bars | The renderer auto-upgrades date-labelled data to a time-axis line | Expected. To force bars, set `"xAxis":"category"` in the marker (or the agent's rule). |
 | Chart renders twice | `scan()` ran more than once on the same answer | The `data-acp-charted` guard prevents this per element; make sure you reuse the same element, not a re-created one. |
 | Agent shows a table but no marker | The chart rule isn't in effect | Re-check Step 1 - the rule must be pasted/added after the agent's other instructions, and saved/redeployed. |

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/high-code-marker-snippet.py
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/high-code-marker-snippet.py
@@ -44,21 +44,34 @@ are both required.
 FORMAT: on its own final line, AFTER the prose, put the chart JSON inside a
 single HTML comment so it never shows in the chat bubble:
 <!--CHART:{"type":"<type>","title":"<short title>","data":[{"label":"<category>","value":<number>}]}-->
+For a TIME-SERIES line chart ONLY, also add "xAxis":"time" and make every "label"
+an ISO date, e.g.:
+<!--CHART:{"type":"line","xAxis":"time","title":"Invoices by month","data":[{"label":"2026-01-01","value":120},{"label":"2026-02-01","value":150}]}-->
 
 CHOOSING "type" - apply IN ORDER, stop at the first match:
-  1. IF the user names a chart type ("as a bar", "as a donut", "as a
-     pyramid / funnel", or any explicit type) use EXACTLY that type. The
-     user's choice wins.
-  2. ELSE if the question is about composition / share / proportion / mix /
-     percentage / split, use "pie".
-  3. ELSE if the answer is a trend over an ordered sequence (over time,
-     "by month / quarter / year", "trend"), use "line".
+  1. IF the user names a chart type ("as a pie", "as a donut / funnel / pyramid",
+     "line chart", or any explicit type) use EXACTLY that type. The user's choice wins.
+  1a. BAR ORIENTATION: a plain "bar" / "horizontal bar" -> use "hbar" (horizontal,
+     the default). Use "bar" (VERTICAL columns) ONLY when the user explicitly asks
+     for a "vertical bar", "column", or "vertical" chart.
+  2. TIME / TREND -> a "line" with a TIME AXIS. Use it whenever the breakdown
+     dimension is a DATE or a calendar period, INCLUDING a plain count or total
+     grouped by time (do NOT fall back to "hbar" just because the phrase is
+     "... by ..."). Triggers: "over time", "trend", ANY "by ... year / quarter /
+     month / week / day", "last N months/weeks/days", "daily / weekly / monthly".
+     For these use "line" AND add "xAxis":"time"; emit each "label" as an ISO date
+     ("YYYY-MM-DD"; a year -> "2020-01-01", a month -> "2026-03-01") in ASCENDING
+     order. (A "line" on NON-time data keeps plain category labels - no "xAxis".)
+  3. ELSE if the question is about composition / share / proportion / mix /
+     percentage / split, use "donut".
   4. ELSE (counts, totals, rankings, comparisons) use "hbar". Default.
 
-"type" is EXACTLY one of: hbar, pie, bar, line, donut, pyramid, funnel (lowercase).
-The data shape is identical for every type ({label,value}); only "type" changes.
-Auto-selection is only ever hbar, pie, or line. NEVER auto-pick bar / donut /
-pyramid / funnel; use those ONLY when the user names them.
+"type" is EXACTLY one of: hbar, bar, donut, pie, funnel, pyramid, line (lowercase).
+The data shape is identical for every type ({label,value}); only "type" (and, for
+a time series, "xAxis":"time") changes. "xAxis":"time" applies ONLY to "line".
+Auto-selection is only ever hbar, donut, or - for a time/calendar breakdown - a
+time-axis "line". NEVER auto-pick bar / pie / funnel / pyramid; use those ONLY
+when the user names them (rules 1 / 1a).
 
 Rules: one object per category in "data" (include EVERY row you listed);
 "value" is a plain number (no quotes, no thousands separators). No code fences,

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/low-code-instructions.md
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/agent/low-code-instructions.md
@@ -25,22 +25,38 @@ Append the block for the exact rows you listed - never skip it because you
 FORMAT: on its own final line, AFTER the prose, put the chart JSON inside a
 single HTML comment so it never shows in the chat bubble:
 <!--CHART:{"type":"<type>","title":"<short title>","data":[{"label":"<category>","value":<number>}]}-->
+For a TIME-SERIES line chart ONLY, also add "xAxis":"time" and make every "label"
+an ISO date, e.g.:
+<!--CHART:{"type":"line","xAxis":"time","title":"Invoices by month","data":[{"label":"2026-01-01","value":120},{"label":"2026-02-01","value":150}]}-->
 
 CHOOSING "type" - apply IN ORDER, stop at the first match:
-  1. IF the user names a chart type ("as a bar", "as a donut", "as a
-     pyramid / funnel", or any explicit type) use EXACTLY that type. The
-     user's choice always wins.
-  2. ELSE if the question is about composition / share / proportion / mix /
-     percentage / split, use "pie".
-  3. ELSE if the answer is a trend over an ordered sequence (over time,
-     "by month / quarter / year", "trend", "over the last N ..."), use "line".
+  1. IF the user names a chart type ("as a pie", "as a donut / funnel / pyramid",
+     "line chart", or any explicit type) use EXACTLY that type. The user's choice
+     always wins.
+  1a. BAR ORIENTATION: a plain "bar" / "bar chart" / "horizontal bar" -> use "hbar"
+     (horizontal, the default). Use "bar" (VERTICAL columns) ONLY when the user
+     explicitly asks for a "vertical bar", "column", or "vertical" chart.
+  2. TIME / TREND -> a "line" with a TIME AXIS. Use it whenever the breakdown
+     dimension is a DATE or a calendar period, INCLUDING a plain count or total
+     grouped by time (a grouped count over time is STILL a time series - do NOT
+     fall back to "hbar" just because the phrase is "... by ..."). Triggers:
+     "over time", "trend", ANY "by ... year / quarter / month / week / day",
+     "last N months/weeks/days", "daily / weekly / monthly". For these use "line"
+     AND add "xAxis":"time"; emit each "label" as an ISO date ("YYYY-MM-DD"; use
+     the FIRST day of the period - a year -> "2020-01-01", a month -> "2026-03-01")
+     and list the points in ASCENDING chronological order. (A "line" the user asks
+     for on NON-time data keeps plain category labels - do NOT add "xAxis".)
+  3. ELSE if the question is about composition / share / proportion / mix /
+     percentage / % / split, use "donut".
   4. ELSE (counts, totals, rankings, comparisons: "break down", "by", "per",
      "each", "how many", "top", "most") use "hbar". Default; when in doubt, "hbar".
 
-"type" is EXACTLY one of: hbar, pie, bar, line, donut, pyramid, funnel (lowercase).
-The data shape is identical for every type ({label,value}); only "type" changes.
-Auto-selection is only ever hbar, pie, or line. NEVER auto-pick bar / donut /
-pyramid / funnel; use those ONLY when the user explicitly names them (rule 1).
+"type" is EXACTLY one of: hbar, bar, donut, pie, funnel, pyramid, line (lowercase).
+The data shape is identical for every type ({label,value}); only "type" (and, for
+a time series, "xAxis":"time") changes. "xAxis":"time" applies ONLY to "line".
+Auto-selection is only ever hbar, donut, or - for a time/calendar breakdown - a
+time-axis "line". NEVER auto-pick bar / pie / funnel / pyramid; use those ONLY
+when the user explicitly names them (rules 1 / 1a).
 
 Rules: one object per category in "data" (include EVERY row you listed);
 "value" is a plain number (no quotes, no thousands separators). Do NOT wrap the
@@ -62,5 +78,12 @@ end with a line such as:
 <!--CHART:{"type":"hbar","title":"Sales by region","data":[{"label":"North","value":120},{"label":"South","value":90},{"label":"East","value":140},{"label":"West","value":75}]}-->
 ```
 
-If you see that line in the raw reply, the APEX region will turn it into an
-inline chart.
+Then ask a time question like *"new customers by signup year"*. That reply
+should end with a time-series line marker:
+
+```
+<!--CHART:{"type":"line","xAxis":"time","title":"New customers by year","data":[{"label":"2022-01-01","value":40},{"label":"2023-01-01","value":65},{"label":"2024-01-01","value":88}]}-->
+```
+
+If you see those lines in the raw reply, the APEX region will turn them into
+inline charts.

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
@@ -15,6 +15,14 @@
  *   - Oracle JET <oj-chart> renders:  hbar, pie, bar, line, pyramid, funnel
  *   - Chart.js renders:               donut  (JET oj-chart has no hole/cutout type)
  *
+ * Two things this renderer decides from the DATA, not the marker:
+ *   - Time series: if every "label" is a date/year AND the type is an auto count
+ *     type (hbar/bar/line), it renders a LINE on a real chronological time axis.
+ *     A model won't reliably pick "line" for "count by year", so we upgrade it
+ *     here. Set "xAxis":"category" in the marker to opt out (a deliberate bar-of-years).
+ *   - bar / hbar legend: a per-category colour legend with click-to-hide, while
+ *     keeping real bars (the single-series "Value" legend would be meaningless).
+ *
  * Dependencies:
  *   - Oracle JET (ships with APEX) provides <oj-chart>.
  *   - Chart.js is loaded on demand, and ONLY when a donut is requested.
@@ -186,6 +194,15 @@
     }).catch(function () { /* Chart.js unavailable: leave the titled card, never break the chat */ });
   }
 
+  // Parse a year / year-month / ISO-date label into a Date, or null if it isn't one.
+  // Used both to detect a time series and to normalise labels for the time axis.
+  function parseIsoDate(value) {
+    if (!value) return null;
+    var parsed = new Date(value);
+    if (isNaN(parsed.getTime())) return null;
+    return parsed;
+  }
+
   // Build the chart card element from a parsed marker spec. Returns the card, or null.
   function buildCard(spec) {
     // data must be a real array — a malformed marker (e.g. "data":"...") would
@@ -209,23 +226,51 @@
 
     // ALL OTHER TYPES: JET oj-chart.
     var cfg = chartType(rawType);
+
+    // TIME-SERIES UPGRADE (decided from the DATA, not the model): if every label
+    // is a year / year-month / full ISO date AND the type is an auto count type
+    // (hbar/bar/line), render a LINE on a real time axis. The strict pattern plus
+    // the parseIsoDate guard mean plain-integer or text categories never fire it.
+    // Explicit pie/donut/funnel/pyramid are left alone; "xAxis":"category" opts out.
+    var labelsAllDates = spec.data.length >= 2 && spec.data.every(function (d) {
+      return /^\d{4}(-\d{2}(-\d{2})?)?$/.test(String(d.label)) && !!parseIsoDate(String(d.label));
+    });
+    if (labelsAllDates && spec.xAxis !== "category" && (rawType === "hbar" || rawType === "bar" || rawType === "line")) {
+      rawType = "line"; spec.xAxis = "time"; cfg = chartType("line");
+    }
+
     // JET data shape:
     //   pie / funnel / pyramid -> ONE series PER category (1 group): distinct colours,
     //                             per-item legend + click-to-hide.
-    //   bar / hbar             -> one series across N groups, one colour per category.
-    //   line                   -> one series across N groups (markers set below).
+    //   line                   -> one series across N groups (xAxis:"time" -> date axis).
+    //   bar / hbar             -> one series across N groups; each item tagged
+    //                             categories:[label] so the custom legend can hide it.
     var nSeries = (cfg.type === "pie" || rawType === "funnel" || rawType === "pyramid");
     var isLine  = (rawType === "line");
+    var isBar   = (cfg.type === "bar");   // vertical bar AND hbar (hbar = bar + horizontal)
+    // TIME AXIS (line only): only when EVERY label is a real date do we render a
+    // chronological date axis; otherwise fall back to a plain category axis so a
+    // mislabelled marker never breaks the chart.
+    var isTimeAxis = isLine && spec.xAxis === "time" && spec.data.every(function (d) { return !!parseIsoDate(d.label); });
     var groups, series;
     if (nSeries) {
       groups = [spec.title || "Total"];
       series = spec.data.map(function (d, i) { return { name: String(d.label), items: [Number(d.value)], color: PALETTE[i % PALETTE.length] }; });
     } else if (isLine) {
-      groups = spec.data.map(function (d) { return String(d.label); });
+      // for a time axis, feed JET normalised ISO dates ("2018" -> "2018-01-01") so it parses + formats the ticks
+      groups = spec.data.map(function (d) {
+        if (isTimeAxis) { var dt = parseIsoDate(String(d.label)); if (dt) return dt.toISOString().slice(0, 10); }
+        return String(d.label);
+      });
       series = [{ name: spec.title || "Value", color: PALETTE[0], lineWidth: 3, items: spec.data.map(function (d) { return Number(d.value); }) }];
     } else {
+      // bar / hbar: displayInLegend:"off" hides the auto SERIES entry ("<title>") so
+      // the legend below shows ONLY the per-category items; categories:[label] links
+      // each bar to its legend item so a legend click hides/shows that one bar.
       groups = spec.data.map(function (d) { return String(d.label); });
-      series = [{ name: spec.title || "Value", items: spec.data.map(function (d, i) { return { value: Number(d.value), color: PALETTE[i % PALETTE.length] }; }) }];
+      series = [{ name: spec.title || "Value", displayInLegend: "off", items: spec.data.map(function (d, i) {
+        return { value: Number(d.value), color: PALETTE[i % PALETTE.length], categories: [String(d.label)] };
+      }) }];
     }
 
     var chart = document.createElement("oj-chart");
@@ -234,15 +279,27 @@
     chart.setAttribute("hover-behavior", "dim");
     chart.setAttribute("animation-on-display", "auto");
     if (nSeries) chart.setAttribute("hide-and-show-behavior", "withRescale");
+    if (isBar) {
+      // bar / hbar: keep the REAL bars (gaps + axis labels) AND add a per-category
+      // colour legend with click-to-unselect. hide-and-show-behavior + each item's
+      // categories (above) let a legend click filter that bar out.
+      chart.setAttribute("hide-and-show-behavior", "withRescale");
+      chart.setAttribute("legend", JSON.stringify({
+        rendered: "on",
+        position: "end",
+        sections: [{
+          items: spec.data.map(function (d, i) {
+            return { id: String(d.label), text: String(d.label), color: PALETTE[i % PALETTE.length], markerShape: "square", categories: [String(d.label)] };
+          })
+        }]
+      }));
+    }
     if (isLine) {
       // sparse single line: show a dot at each point, and drop the 1-item legend
       chart.setAttribute("style-defaults", JSON.stringify({ markerDisplayed: "on" }));
       chart.setAttribute("legend", JSON.stringify({ rendered: "off" }));
-    }
-    if (!nSeries && !isLine) {
-      // bar / hbar: the bars are already labeled on the axis, so the single-series
-      // legend ("Value") is redundant and misleading - drop it.
-      chart.setAttribute("legend", JSON.stringify({ rendered: "off" }));
+      // time-series: ISO-date group labels -> a real chronological, date-formatted x-axis
+      if (isTimeAxis) chart.setAttribute("time-axis-type", "enabled");
     }
     chart.style.width = "100%";
     chart.style.height = "340px";

--- a/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
+++ b/ai/agent-flows/misc/apex-chat-charts-over-oac-mcp/apex/render_chart_marker.js
@@ -191,7 +191,31 @@
         },
         plugins: [centerTotal, slicePct]
       });
-    }).catch(function () { /* Chart.js unavailable: leave the titled card, never break the chat */ });
+    }).catch(function () {
+      // Chart.js unavailable (blocked CDN / offline). Since the agent AUTO-picks
+      // donut for composition questions, an empty card here would be the default
+      // failure mode on locked-down networks — so fall back to the JET pie
+      // (no CDN, same data, just no centre total) instead of giving up.
+      wrap.remove();
+      card.appendChild(buildJetChart("pie", spec));
+    });
+  }
+
+  // Build a JET <oj-chart> for the one-series-per-category types (pie & friends).
+  // Used by the donut CDN fallback; kept minimal on purpose.
+  function buildJetChart(jetType, spec) {
+    var chart = document.createElement("oj-chart");
+    chart.setAttribute("type", jetType);
+    chart.setAttribute("hover-behavior", "dim");
+    chart.setAttribute("animation-on-display", "auto");
+    chart.setAttribute("hide-and-show-behavior", "withRescale");
+    chart.style.width = "100%";
+    chart.style.height = "340px";
+    chart.setAttribute("groups", JSON.stringify([spec.title || "Total"]));
+    chart.setAttribute("series", JSON.stringify(spec.data.map(function (d, i) {
+      return { name: String(d.label), items: [Number(d.value)], color: PALETTE[i % PALETTE.length] };
+    })));
+    return chart;
   }
 
   // Parse a year / year-month / ISO-date label into a Date, or null if it isn't one.
@@ -233,7 +257,14 @@
     // the parseIsoDate guard mean plain-integer or text categories never fire it.
     // Explicit pie/donut/funnel/pyramid are left alone; "xAxis":"category" opts out.
     var labelsAllDates = spec.data.length >= 2 && spec.data.every(function (d) {
-      return /^\d{4}(-\d{2}(-\d{2})?)?$/.test(String(d.label)) && !!parseIsoDate(String(d.label));
+      var s = String(d.label);
+      if (!/^\d{4}(-\d{2}(-\d{2})?)?$/.test(s) || !parseIsoDate(s)) return false;
+      // A BARE 4-digit label is only a "year" inside a plausible window —
+      // otherwise 4-digit CATEGORY CODES (departments 1001/2001, ZIP/postal
+      // prefixes, PINs) would silently upgrade a ranking into a "time series"
+      // spanning the year 1001. Hyphenated labels (2026-03) are unambiguous.
+      if (/^\d{4}$/.test(s)) { var y = +s; if (y < 1900 || y > 2100) return false; }
+      return true;
     });
     if (labelsAllDates && spec.xAxis !== "category" && (rawType === "hbar" || rawType === "bar" || rawType === "line")) {
       rawType = "line"; spec.xAxis = "time"; cfg = chartType("line");


### PR DESCRIPTION
## What
Enhances the `apex-chat-charts-over-oac-mcp` sample (added in #85) with two chart-layer improvements, both verified in a live APEX chat.

### 1. Time-axis line charts
When a breakdown is by date/period, the answer renders as a line on a real chronological time axis (`time-axis-type`). The renderer also **upgrades a date-labelled `hbar`/`bar` to a time-axis line**, so a "count by year" reads as a trend even when the model picked `hbar`. The upgrade is deterministic and data-driven (strict date pattern + a parse guard), so plain-integer or text categories never trigger it; opt out with `xAxis:"category"`.

### 2. Clickable bar legend
`hbar`/`bar` charts get a per-category colour legend with click-to-hide, while keeping the real bars (the single-series "Value" legend was meaningless).

### Also
- Agent chart rule (low-code + high-code) aligned: composition -> `donut`; time/date breakdown -> time-axis `line` (`xAxis:"time"` + ISO labels, ascending); bar-orientation rule. Auto-pick is `hbar` / `donut` / a time-axis `line`.
- README: new optional `xAxis` field in the marker spec, updated types table + auto-pick description, and a troubleshooting row.

## Scope
Chart-layer only, fully generalized: no secrets, no environment-specific values, all example data invented.

## Testing
- `render_chart_marker.js` passes `node --check`.
- `high-code-marker-snippet.py` parses via `ast.parse`.
- Behaviour verified in a live APEX chat region over an OAC-MCP agent.

Closes #87.