### PR TITLE
fix(ask-aidp): update Codex plugin to 0.9.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,68 @@
+{
+  "name": "oracle-aidp-codex",
+  "interface": {
+    "displayName": "Oracle AI Data Platform - Codex"
+  },
+  "plugins": [
+    {
+      "name": "oracle-ai-data-platform-workbench-databricks-migrator",
+      "source": {
+        "source": "local",
+        "path": "./ai/codex-plugins/plugins/oracle-ai-data-platform-workbench-databricks-migrator"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    },
+    {
+      "name": "oracle-ai-data-platform-workbench-engineer-agent",
+      "source": {
+        "source": "local",
+        "path": "./ai/codex-plugins/plugins/oracle-ai-data-platform-workbench-engineer-agent"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Data"
+    },
+    {
+      "name": "oracle-ai-data-platform-workbench-spark-connectors",
+      "source": {
+        "source": "local",
+        "path": "./ai/codex-plugins/plugins/oracle-ai-data-platform-workbench-spark-connectors"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Data"
+    },
+    {
+      "name": "ask-aidp",
+      "source": {
+        "source": "local",
+        "path": "./ai/codex-plugins/plugins/ask-aidp"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Data"
+    },
+    {
+      "name": "oracle-ai-data-platform-fusion-autopilot",
+      "source": {
+        "source": "local",
+        "path": "./ai/codex-plugins/plugins/oracle-ai-data-platform-fusion-autopilot"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Data"
+    }
+  ]
+}

--- a/ai/codex-plugins/README.md
+++ b/ai/codex-plugins/README.md
@@ -5,7 +5,11 @@ A marketplace of OpenAI Codex CLI plugins for Oracle AI Data Platform (AIDP).
 ## Marketplace
 
 - **Name:** `oracle-aidp-codex`
-- **Manifest:** [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json)
+- **Git repository manifest:** [`.agents/plugins/marketplace.json`](../../.agents/plugins/marketplace.json)
+- **Local directory manifest:** [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json)
+
+The repository-root manifest supports GitHub marketplace installation. The nested
+manifest remains available when registering a local `ai/codex-plugins` checkout.
 
 ## Plugins
 
@@ -14,7 +18,7 @@ A marketplace of OpenAI Codex CLI plugins for Oracle AI Data Platform (AIDP).
 | [`oracle-ai-data-platform-workbench-databricks-migrator`](./plugins/oracle-ai-data-platform-workbench-databricks-migrator/) | 0.1.0 | Initial release | Plan and execute automated Databricks to AIDP migrations from Codex. |
 | [`oracle-ai-data-platform-workbench-engineer-agent`](./plugins/oracle-ai-data-platform-workbench-engineer-agent/) | 0.1.0+codex.20260623113518 | Initial release | Full AIDP data-engineering surface in natural language: catalog discovery, SQL analysis, AI-in-SQL, Delta operations, pipelines, clusters, governance, agent flows, MLOps, migration, and workspace administration. |
 | [`oracle-ai-data-platform-workbench-spark-connectors`](./plugins/oracle-ai-data-platform-workbench-spark-connectors/) | 0.7.0 | DB2 + Azure SQL connector guidance | Generate AIDP Spark notebook connector code for Oracle, OCI, SaaS, JDBC, object storage, streaming, REST, Excel, and multi-cloud data sources. |
-| [`ask-aidp`](./plugins/ask-aidp/) | 0.7.2 | Initial release | Ask and operate Oracle AI Data Platform resources from Codex through aidp-cli and native SDK Git tools. |
+| [`ask-aidp`](./plugins/ask-aidp/) | 0.9.1 | Current release | Ask and operate Oracle AI Data Platform resources from Codex through aidp-cli, OCI-signed REST endpoints, and native SDK tools. |
 | [`oracle-ai-data-platform-fusion-autopilot`](./plugins/oracle-ai-data-platform-fusion-autopilot/) | 0.1.0-alpha | Initial release | Build and operate curated Oracle Fusion ERP/HCM/SCM-to-AIDP medallion pipelines (BICC extracts, bronze/silver/gold content packs, guarded bootstrap/seed/incremental runs), gold marts, OAC datasets, and MCP-authored workbooks. |
 
 ## Install
@@ -24,6 +28,7 @@ Register the marketplace:
 ```bash
 codex plugin marketplace add oracle-samples/oracle-aidp-samples \
     --ref main \
+    --sparse .agents \
     --sparse ai/codex-plugins
 ```
 
@@ -43,7 +48,8 @@ Verify:
 codex plugin list
 ```
 
-Start a new Codex thread after installing or upgrading plugins.
+Restart the Codex app after installing or upgrading plugins, then start a new
+thread so the updated skills and MCP servers are loaded.
 
 ## Update
 
@@ -59,18 +65,23 @@ codex plugin add oracle-ai-data-platform-workbench-spark-connectors@oracle-aidp-
 codex plugin add ask-aidp@oracle-aidp-codex
 ```
 
+Restart the Codex app after refreshing a plugin.
+
 ## Layout
 
 ```text
-ai/codex-plugins/
+oracle-aidp-samples/
 |-- .agents/plugins/marketplace.json
-|-- README.md
-|-- TESTING.md
-`-- plugins/
-    |-- oracle-ai-data-platform-workbench-databricks-migrator/
-    |-- oracle-ai-data-platform-workbench-engineer-agent/
-    |-- oracle-ai-data-platform-workbench-spark-connectors/
-    `-- ask-aidp/
+`-- ai/codex-plugins/
+    |-- .agents/plugins/marketplace.json
+    |-- README.md
+    |-- TESTING.md
+    `-- plugins/
+        |-- oracle-ai-data-platform-workbench-databricks-migrator/
+        |-- oracle-ai-data-platform-workbench-engineer-agent/
+        |-- oracle-ai-data-platform-workbench-spark-connectors/
+        |-- ask-aidp/
+        `-- oracle-ai-data-platform-fusion-autopilot/
 ```
 
 Each plugin has its own `.codex-plugin/plugin.json`, README, license/privacy files, skills, and references or helper files.

--- a/ai/codex-plugins/plugins/ask-aidp/.codex-plugin/plugin.json
+++ b/ai/codex-plugins/plugins/ask-aidp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ask-aidp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Ask and operate Oracle AI Data Platform resources from Codex through aidp-cli, signed REST, and native SDK Git tools.",
   "author": {
     "name": "Oracle",

--- a/ai/codex-plugins/plugins/ask-aidp/CHANGELOG.md
+++ b/ai/codex-plugins/plugins/ask-aidp/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this plugin are documented here.
 
+## [0.9.1] - 2026-08-27
+
+### Fixed
+
+- Stage inline-row CSV data without a header and use positional `selectedColumns`
+  so `schema create-data-table` does not ingest the header as a data row.
+- Upload workspace files through `WorkspaceObjectClient#createWorkspaceObject`,
+  with safe folder-conflict handling and dry-run placeholders that do not require
+  an instance OCID or read file contents.
+- Fail offline packaging when the vendor source is missing `aidp-cli`,
+  `aidp-typescript-client`, or `oci-common` instead of producing an incomplete
+  archive.
+
+### Changed
+
+- Strengthen static QA with exact version/tool-count checks, portable MCP and
+  symlink validation, marketplace resolution, JSON-only stdout enforcement, and
+  regression coverage for workspace upload and inline-row table loading.
+- Make prompt-based installation the recommended first option and document Codex
+  app restarts, post-install verification, environment inheritance, and guarded
+  offline packaging on macOS, Linux, and Windows.
+
 ## [0.9.0] - 2026-07-20
 
 ### Added

--- a/ai/codex-plugins/plugins/ask-aidp/README.md
+++ b/ai/codex-plugins/plugins/ask-aidp/README.md
@@ -4,13 +4,14 @@ This plugin connects Codex to Oracle AI Data Platform Workbench through every do
 
 ## Requirements
 
-- Codex CLI with plugin support and Node.js available to Codex.
+- Codex CLI with the `plugin` subcommand and Node.js available to Codex. The
+  installation flow is verified on `codex-cli 0.147.0`.
 - OCI config and credentials that can access the target AIDP instance.
 - The latest `aidp-cli` from
   [`oracle-samples/aidataplatform-sdk`](https://github.com/oracle-samples/aidataplatform-sdk),
   either on `PATH` or selected with `AIDP_CLI_BIN`.
 - The latest `aidp-typescript-client` and `oci-common` packages when using the
-  native SDK workspace Git tools.
+  native SDK workspace upload and Git tools.
 
 This GitHub directory is the plugin's source distribution. It does **not** contain
 generated `dist/` tarballs, zip files, or a vendored `node_modules` tree. Install the
@@ -22,7 +23,18 @@ For file work in notebooks, use AIDP Workbench path patterns such as `/Volumes/<
 
 For REST-only or advanced operations, use `aidp_rest_api_reference` to find the documented operation, then call `aidp_rest` with `dryRun: true` before a live request. The plugin signs the request with the configured OCI identity and only permits endpoint/method pairs from the generated Oracle REST catalog. The current documented endpoint version is `/20260430`.
 
-## Install From GitHub
+## Install Or Update With Codex — Recommended
+
+The easiest way to install or update the plugin is to prompt Codex with:
+
+```text
+Install or update plugin from https://github.com/oracle-samples/oracle-aidp-samples/tree/main/ai/codex-plugins/plugins/ask-aidp
+```
+
+After installation or update, restart the Codex app so it reloads the plugin,
+skill, and MCP server.
+
+## Install From GitHub Manually
 
 The same marketplace commands work on macOS, Linux, and Windows. Register the
 Oracle AIDP marketplace once:
@@ -30,6 +42,7 @@ Oracle AIDP marketplace once:
 ```bash
 codex plugin marketplace add oracle-samples/oracle-aidp-samples \
     --ref main \
+    --sparse .agents \
     --sparse ai/codex-plugins
 ```
 
@@ -45,9 +58,9 @@ Verify the installation:
 codex plugin list
 ```
 
-Start a new Codex thread after installation so the Ask AIDP skill and MCP tools
-are loaded. You do not need to download an archive, extract a plugin directory,
-or create `~/.agents/plugins/marketplace.json` manually.
+Restart the Codex app after installation, then start a new thread so the Ask AIDP
+skill and MCP tools are loaded. You do not need to download an archive, extract a
+plugin directory, or create `~/.agents/plugins/marketplace.json` manually.
 
 To update an existing installation:
 
@@ -56,13 +69,38 @@ codex plugin marketplace upgrade oracle-aidp-codex
 codex plugin add ask-aidp@oracle-aidp-codex
 ```
 
-Then start another new Codex thread.
+Restart the Codex app, then start another new thread.
+
+## Verify The Install
+
+Confirm that Codex installed and enabled version `0.9.1` and registered the MCP
+server:
+
+```bash
+codex plugin list
+codex mcp list
+```
+
+Maintainers and users working from a repository checkout can run the static QA
+suite. It does not contact AIDP or OCI, but it requires `aidp` on `PATH` or
+`AIDP_CLI_BIN` to point to the CLI executable:
+
+```bash
+cd ai/codex-plugins/plugins/ask-aidp
+node scripts/qa.mjs
+```
+
+Expected: `"ok": true`, 43 MCP tools, 242 CLI commands, and 257 REST operations.
 
 ## Configure AIDP
 
 Use [`examples/aidp.env.sample`](./examples/aidp.env.sample) as the template. Do
 not distribute a completed `aidp.env`, because it identifies a user's OCI profile,
 AIDP instance, workspace, and cluster.
+
+The MCP configuration does not inject environment variables. Configure them in
+the shell that launches Codex and restart an already-running Codex app after
+changing them.
 
 On macOS or Linux, download and load the sample from the shell that launches
 Codex:
@@ -107,6 +145,27 @@ If `oci login` does not work, configure OCI API key authentication using
 [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two).
 Set `AIDP_AUTH=api_key`, select the profile with `OCI_PROFILE`, and set
 `OCI_CONFIG_FILE` when the OCI config is not in its default location.
+
+## Build Offline Archives — Maintainers
+
+The package build fails if its vendor source does not contain `aidp-cli`,
+`aidp-typescript-client`, and `oci-common`; this prevents publishing an archive
+that cannot run offline. On macOS or Linux, run from the repository root:
+
+```sh
+AIDP_VENDOR_NODE_MODULES=/absolute/path/to/node_modules \
+  node ai/codex-plugins/plugins/ask-aidp/scripts/package-plugin.mjs
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:AIDP_VENDOR_NODE_MODULES = "C:\absolute\path\to\node_modules"
+node ai/codex-plugins/plugins/ask-aidp/scripts/package-plugin.mjs
+```
+
+The archives, environment sample, and SHA-256 checksum file are written to
+`ai/codex-plugins/plugins/ask-aidp/dist/`.
 
 ## Use
 
@@ -226,6 +285,10 @@ The create-schema, create-Delta-table, create-table-with-data, create-catalog, a
 - `localDataFile`, which the tool stages through the same temporary upload target;
 - `objectStorageLocationPath`, when the data file is already in object storage.
 
+For inline `rows`, the staged CSV is headerless because `create-data-table` reads
+the source positionally. The tool uses `_c0`, `_c1`, and so on in
+`selectedColumns`; `tableFields` retains the real column names and types.
+
 This is an initial-load workflow for a newly-created managed table. For appending rows to an existing table, use `aidp_cli` or a notebook/workflow if that operation is exposed by your AIDP environment.
 
 Auto-heal workflow prompt:
@@ -258,5 +321,5 @@ Workflow runs create a local evidence directory with:
 - `aidp_create_table_with_data` uses `schema create-data-table`, which creates a managed table with an initial data load. It is not a general-purpose append/merge command for existing tables.
 - The GitHub marketplace source does not include generated archives or vendored
   Node dependencies. Install `aidp-cli` separately and set `AIDP_CLI_BIN` or
-  `PATH`; native workspace Git tools additionally require
+  `PATH`; native workspace upload and Git tools additionally require
   `aidp-typescript-client` and `oci-common` to be resolvable by the MCP server.

--- a/ai/codex-plugins/plugins/ask-aidp/assets/aidp-cli-command-reference.json
+++ b/ai/codex-plugins/plugins/ask-aidp/assets/aidp-cli-command-reference.json
@@ -1450,7 +1450,7 @@
           "anchor": "schema-create-data-table",
           "fullName": "aidp schema create-data-table",
           "command": "create-data-table",
-          "summary": "Creates a managed table with data loaded from a sample file.",
+          "summary": "Creates a managed table with data loaded from a sample file. CSV input is read positionally: use a headerless file and _c0, _c1, ... in selectedColumns, with real names and types in tableFields.",
           "usage": "aidp schema create-data-table <AI-DATA-PLATFORM-ID> --body <JSON>",
           "bodyModel": "CreateDataTableDetails"
         },
@@ -5429,7 +5429,7 @@
       "group": "schema",
       "command": "create-data-table",
       "anchor": "schema-create-data-table",
-      "summary": "Creates a managed table with data loaded from a sample file.",
+      "summary": "Creates a managed table with data loaded from a sample file. CSV input is read positionally: use a headerless file and _c0, _c1, ... in selectedColumns, with real names and types in tableFields.",
       "usage": "aidp schema create-data-table <AI-DATA-PLATFORM-ID> --body <JSON>",
       "bodyModel": "CreateDataTableDetails",
       "bodyFields": [

--- a/ai/codex-plugins/plugins/ask-aidp/mcp/ask-aidp-server.mjs
+++ b/ai/codex-plugins/plugins/ask-aidp/mcp/ask-aidp-server.mjs
@@ -10,7 +10,7 @@ import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 
-const SERVER_VERSION = '0.9.0';
+const SERVER_VERSION = '0.9.1';
 const SERVER_NAME = 'ask-aidp';
 const __filename = fileURLToPath(import.meta.url);
 const PLUGIN_ROOT = path.resolve(path.dirname(__filename), '..');
@@ -724,7 +724,12 @@ const TOOLS = [
             }
           ]
         },
-        csvIncludeHeader: { type: 'boolean', default: true },
+        csvIncludeHeader: {
+          type: 'boolean',
+          const: false,
+          default: false,
+          description: 'Deprecated compatibility input. Inline-row CSV must remain headerless because create-data-table reads columns positionally.'
+        },
         uploadMethod: { type: 'string', enum: ['PUT', 'POST'], default: 'PUT' },
         uploadContentType: { type: 'string', description: 'Optional content type for staged local data upload.' },
         uploadTargetBaseUrl: { type: 'string', description: 'Optional base object storage URL if AIDP returns a relative tempFileUploadTarget.' },
@@ -1356,6 +1361,22 @@ function sdkResponseToJson(response) {
     if (typeof value === 'function') return undefined;
     return value;
   }, 2);
+}
+
+function sdkErrorStatus(error) {
+  return error?.statusCode ?? error?.status ?? error?.response?.status;
+}
+
+function isConflictError(error) {
+  return sdkErrorStatus(error) === 409 || /already exists/i.test(error?.message || '');
+}
+
+function sdkErrorToJson(error) {
+  return {
+    message: error?.message || String(error),
+    statusCode: sdkErrorStatus(error),
+    code: error?.code || error?.serviceCode
+  };
 }
 
 function sdkDryRun(operation, request) {
@@ -2187,7 +2208,7 @@ async function createTableWithData(input) {
     throw new Error('Inline rows are staged as CSV. Use localDataFile or objectStorageLocationPath for non-CSV fileFormat values.');
   }
 
-  const body = buildCreateDataTableBody(input, source.objectStorageLocationPath || '<generated-oci-file-path>', fileFormat);
+  const body = buildCreateDataTableBody(input, source.objectStorageLocationPath || '<generated-oci-file-path>', fileFormat, source.kind);
   const command = scrubCommand(['schema', 'create-data-table', '--body', '@<generated-json>', ...commonFlags(config)]);
 
   if (input.dryRun === true) {
@@ -2206,7 +2227,7 @@ async function createTableWithData(input) {
           },
       command,
       body,
-      dataPreview: source.kind === 'rows' ? truncate(rowsToCsv(input.rows, body.selectedColumns, input.csvIncludeHeader !== false), 2000) : undefined
+      dataPreview: source.kind === 'rows' ? truncate(rowsToCsv(input.rows, dataColumnsFor(input), false), 2000) : undefined
     }, null, 2));
   }
 
@@ -2218,7 +2239,7 @@ async function createTableWithData(input) {
     if (!objectStorageLocationPath) {
       tempDir = await mkdtemp(path.join(tmpdir(), 'ask-aidp-data-'));
       const dataFile = source.kind === 'rows'
-        ? writeRowsDataFile(input, body.selectedColumns, tempDir)
+        ? writeRowsDataFile(input, dataColumnsFor(input), tempDir)
         : validateLocalDataFile(input.localDataFile, input.maxUploadBytes || 10485760);
 
       const uploadTarget = await runAidp(['schema', 'generate-temp-file-upload-target', input.schemaKey], {
@@ -2255,7 +2276,7 @@ async function createTableWithData(input) {
       };
     }
 
-    const createBody = buildCreateDataTableBody(input, objectStorageLocationPath, fileFormat);
+    const createBody = buildCreateDataTableBody(input, objectStorageLocationPath, fileFormat, source.kind);
     const create = await runGeneratedJsonCommand(['schema', 'create-data-table'], createBody, config, input.timeoutSeconds || 120);
     const response = {
       created: create.exitCode === 0,
@@ -2558,12 +2579,25 @@ function normalizeDataTableField(field, rows = []) {
   return normalized;
 }
 
-function buildCreateDataTableBody(input, objectStorageLocationPath, fileFormat) {
+function dataColumnsFor(input) {
   const rows = Array.isArray(input.rows) ? input.rows : [];
   const tableFields = buildDataTableFields(input, rows);
-  const selectedColumns = input.selectedColumns?.length
+  return input.selectedColumns?.length
     ? input.selectedColumns
     : tableFields.map((field) => field.fieldName);
+}
+
+function positionalColumns(count) {
+  return Array.from({ length: count }, (_, index) => `_c${index}`);
+}
+
+function buildCreateDataTableBody(input, objectStorageLocationPath, fileFormat, sourceKind) {
+  const rows = Array.isArray(input.rows) ? input.rows : [];
+  const tableFields = buildDataTableFields(input, rows);
+  const dataColumns = dataColumnsFor(input);
+  const selectedColumns = sourceKind === 'rows'
+    ? positionalColumns(dataColumns.length)
+    : dataColumns;
   const body = {
     catalogKey: requireValue(input.catalogKey, 'catalogKey'),
     schemaKey: requireValue(input.schemaKey, 'schemaKey'),
@@ -2648,8 +2682,8 @@ function csvCell(value) {
   return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }
 
-function writeRowsDataFile(input, selectedColumns, tempDir) {
-  const csv = rowsToCsv(input.rows, selectedColumns, input.csvIncludeHeader !== false);
+function writeRowsDataFile(input, dataColumns, tempDir) {
+  const csv = rowsToCsv(input.rows, dataColumns, false);
   const bytes = Buffer.byteLength(csv);
   const maxUploadBytes = input.maxUploadBytes || 10485760;
   if (bytes > maxUploadBytes) throw new Error(`Generated CSV is ${bytes} bytes, exceeding maxUploadBytes=${maxUploadBytes}.`);
@@ -2829,13 +2863,6 @@ function walkUploadDirectory(root, current, workspaceRoot, entries, options) {
       entries.push({ kind: 'file', localPath: fullPath, relativePath: rel, workspacePath });
     }
   }
-}
-
-function uploadEntryCommand(workspaceKey, entry, overwrite, config) {
-  const args = entry.kind === 'folder'
-    ? ['workspace-object', 'create', workspaceKey, '--path', entry.workspacePath, '--type', 'FOLDER', '--is-overwrite', String(overwrite), '--body', '{}']
-    : ['workspace-object', 'create', workspaceKey, '--path', entry.workspacePath, '--type', 'FILE', '--is-overwrite', String(overwrite), '--body', `@${entry.localPath}`];
-  return scrubCommand([...args, ...commonFlags(config)]);
 }
 
 function normalizeWorkspacePath(value) {
@@ -3127,26 +3154,62 @@ async function uploadWorkspaceCode(input) {
   const config = workflowConfig(input.config || {});
   const workspaceKey = requireValue(config.workspaceKey, 'workspaceKey or AIDP_WORKSPACE_KEY');
   const entries = buildUploadEntries(input);
-  const commands = entries.map((entry) => uploadEntryCommand(workspaceKey, entry, input.overwrite !== false, config));
+  const overwrite = input.overwrite !== false;
+
+  const buildRequest = (entry) => {
+    const isFolder = entry.kind === 'folder';
+    return {
+      aiDataPlatformId: requireValue(config.instanceId, 'instanceId, AIDP_OCID, or AIDP_INSTANCE_ID'),
+      workspaceKey,
+      path: entry.workspacePath,
+      type: isFolder ? 'FOLDER' : 'FILE',
+      isOverwrite: overwrite,
+      isUploadFileBase64Encoded: !isFolder,
+      createWorkspaceObjectDetails: isFolder ? '{}' : readFileSync(entry.localPath).toString('base64')
+    };
+  };
 
   if (input.dryRun === true) {
     return toolText(JSON.stringify({
       dryRun: true,
+      implementation: 'aidp-typescript-client WorkspaceObjectClient#createWorkspaceObject',
       localPath: path.resolve(input.localPath),
       workspacePath: input.workspacePath,
       entryCount: entries.length,
-      entries: entries.map((entry, index) => ({ ...entry, command: commands[index] }))
+      entries: entries.map((entry) => ({
+        ...entry,
+        operation: 'WorkspaceObjectClient#createWorkspaceObject',
+        request: {
+          aiDataPlatformId: config.instanceId || '<aiDataPlatformId>',
+          workspaceKey,
+          path: entry.workspacePath,
+          type: entry.kind === 'folder' ? 'FOLDER' : 'FILE',
+          isOverwrite: overwrite,
+          isUploadFileBase64Encoded: entry.kind !== 'folder',
+          createWorkspaceObjectDetails: entry.kind === 'folder' ? '{}' : `<base64:${entry.localPath}>`
+        }
+      }))
     }, null, 2));
   }
 
+  const client = await createWorkspaceObjectClient(config);
   const results = [];
-  for (const entry of entries) {
-    const args = entry.kind === 'folder'
-      ? ['workspace-object', 'create', workspaceKey, '--path', entry.workspacePath, '--type', 'FOLDER', '--is-overwrite', String(input.overwrite !== false), '--body', '{}']
-      : ['workspace-object', 'create', workspaceKey, '--path', entry.workspacePath, '--type', 'FILE', '--is-overwrite', String(input.overwrite !== false), '--body', `@${entry.localPath}`];
-    const result = await runAidp(args, { config, timeoutSeconds: input.timeoutSeconds || 120 });
-    results.push({ entry, command: result.command, exitCode: result.exitCode, response: safeData(result) });
-    if (result.exitCode !== 0) return toolText(JSON.stringify({ uploaded: false, results }, null, 2), true);
+  try {
+    for (const entry of entries) {
+      try {
+        const response = await client.createWorkspaceObject(buildRequest(entry));
+        results.push({ entry, operation: 'WorkspaceObjectClient#createWorkspaceObject', response: JSON.parse(sdkResponseToJson(response)) });
+      } catch (error) {
+        if (entry.kind === 'folder' && isConflictError(error)) {
+          results.push({ entry, operation: 'WorkspaceObjectClient#createWorkspaceObject', skipped: 'folder already exists' });
+          continue;
+        }
+        results.push({ entry, operation: 'WorkspaceObjectClient#createWorkspaceObject', error: sdkErrorToJson(error) });
+        return toolText(JSON.stringify({ uploaded: false, results }, null, 2), true);
+      }
+    }
+  } finally {
+    client.close?.();
   }
 
   return toolText(JSON.stringify({ uploaded: true, entryCount: entries.length, results }, null, 2));

--- a/ai/codex-plugins/plugins/ask-aidp/mcp/ask-aidp-server.mjs
+++ b/ai/codex-plugins/plugins/ask-aidp/mcp/ask-aidp-server.mjs
@@ -1462,17 +1462,49 @@ function normalizeSpawnTarget(command, args) {
   if (process.platform !== 'win32') return { command, args };
   const lower = command.toLowerCase();
   if (!lower.endsWith('.cmd') && !lower.endsWith('.bat')) return { command, args };
-  return {
-    command: process.env.ComSpec || 'cmd.exe',
-    args: ['/d', '/s', '/c', [quoteWindowsCmdArg(command), ...args.map(quoteWindowsCmdArg)].join(' ')]
-  };
+  // SECURITY: never invoke a .cmd/.bat shim through cmd.exe with interpolated
+  // arguments. cmd.exe's quoting cannot be made safe for a value containing a
+  // double-quote — it terminates the quoted region and drops back to unquoted
+  // parsing where &, |, > become command separators (RCE; CVE-2024-27980 /
+  // "BatBadBut" class). Instead resolve the shim to the Node script it wraps
+  // and spawn Node directly with an argv ARRAY (shell:false), so every
+  // metacharacter — the double-quote included — is passed as inert literal
+  // data. Fail closed if the underlying script can't be resolved.
+  const script = resolveCmdShimToNode(command);
+  if (script) return { command: process.execPath, args: [script, ...args] };
+  throw new Error(
+    `Refusing to execute the aidp CLI via the Windows shim ${command}: arguments ` +
+    `cannot be passed safely through cmd.exe. Point AIDP_CLI_BIN at the aidp Node ` +
+    `entry script (…/aidp-cli/dist/bin/aidp.js) or the platform binary instead.`
+  );
 }
 
-function quoteWindowsCmdArg(value) {
-  const text = String(value);
-  if (text === '') return '""';
-  if (!/[\s"&()<>^|%]/.test(text)) return text;
-  return `"${text.replace(/(["^&|<>()%])/g, '^$1')}"`;
+function resolveCmdShimToNode(cmdPath) {
+  // npm/pnpm/yarn .cmd/.bat shims launch Node against a wrapped .js entry, but
+  // the exact spelling of that path varies by generator/version — all of these
+  // occur in the wild:
+  //   "%~dp0\node_modules\aidp-cli\dist\bin\aidp.js"   (older npm)
+  //   "%dp0%\..\aidp-cli\dist\bin\aidp.js"             (current npm; dp0 var + relative ..)
+  //   "%~dp0../aidp-cli/dist/bin/aidp.js"              (forward slashes)
+  // Extract EVERY .js token, strip the dp0 directory variable, resolve what
+  // remains against the shim's own directory (honouring `..`), and return the
+  // first path that exists. Bypassing cmd.exe entirely is the whole point
+  // (see normalizeSpawnTarget); resolving Node's real entry robustly is what
+  // keeps the normal Windows aidp.cmd install working after that change.
+  let text;
+  try { text = readFileSync(cmdPath, 'utf8'); } catch { return null; }
+  const dir = path.dirname(cmdPath);
+  const tokens = text.match(/[^\s"'\r\n]+\.js\b/gi) || [];
+  for (const token of tokens) {
+    // Strip a leading dp0 directory variable in any of its spellings:
+    // %~dp0 , %dp0% , %dp0  — optionally followed by a path separator.
+    let rel = token.replace(/^%~?dp0%?[\\/]?/i, '');
+    if (rel.includes('%')) continue;             // still carries an unresolved %VAR% — skip
+    rel = rel.replace(/[\\/]+/g, path.sep);
+    const resolved = path.isAbsolute(rel) ? rel : path.resolve(dir, rel);
+    if (existsSync(resolved)) return resolved;
+  }
+  return null;
 }
 
 function parseCliJson(result) {

--- a/ai/codex-plugins/plugins/ask-aidp/scripts/generate-cli-command-reference.mjs
+++ b/ai/codex-plugins/plugins/ask-aidp/scripts/generate-cli-command-reference.mjs
@@ -114,6 +114,19 @@ while ((sectionMatch = sectionPattern.exec(markdown))) {
   });
 }
 
+const commandSummarySuffixes = new Map([
+  [
+    'aidp schema create-data-table',
+    'CSV input is read positionally: use a headerless file and _c0, _c1, ... in selectedColumns, with real names and types in tableFields.'
+  ]
+]);
+for (const command of commands) {
+  const suffix = commandSummarySuffixes.get(command.fullName);
+  if (suffix && !command.summary.includes(suffix)) {
+    command.summary = `${command.summary} ${suffix}`.trim();
+  }
+}
+
 const byFullName = new Map(commands.map((command) => [command.fullName, command]));
 for (const group of groups) {
   for (const command of group.commands) {

--- a/ai/codex-plugins/plugins/ask-aidp/scripts/package-plugin.mjs
+++ b/ai/codex-plugins/plugins/ask-aidp/scripts/package-plugin.mjs
@@ -2,6 +2,7 @@
 import { spawnSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,7 +10,7 @@ const __filename = fileURLToPath(import.meta.url);
 const PLUGIN_ROOT = path.resolve(path.dirname(__filename), '..');
 const WORKSPACE_ROOT = path.resolve(PLUGIN_ROOT, '..', '..');
 const DIST_DIR = path.join(PLUGIN_ROOT, 'dist');
-const STAGING_ROOT = path.join(WORKSPACE_ROOT, '.plugin-build');
+const STAGING_ROOT = path.join(tmpdir(), 'ask-aidp-codex-plugin-build');
 const STAGING_PLUGIN = path.join(STAGING_ROOT, 'ask-aidp');
 const version = JSON.parse(readFileSync(path.join(PLUGIN_ROOT, '.codex-plugin', 'plugin.json'), 'utf8')).version;
 const baseName = `ask-aidp-codex-plugin-${version}`;
@@ -22,23 +23,32 @@ function run(command, args, cwd = WORKSPACE_ROOT) {
 rmSync(STAGING_ROOT, { recursive: true, force: true });
 mkdirSync(STAGING_ROOT, { recursive: true });
 mkdirSync(DIST_DIR, { recursive: true });
+const STAGING_EXCLUDES = new Set(['vendor', 'dist', 'qa-runs', 'qa-live-result.json', 'aidp.env', '.DS_Store']);
 cpSync(PLUGIN_ROOT, STAGING_PLUGIN, {
   recursive: true,
   filter: (src) => {
     const rel = path.relative(PLUGIN_ROOT, src);
-    return !rel.startsWith('qa-live-result.json')
-      && !rel.startsWith('qa-runs')
-      && !rel.startsWith('vendor')
-      && !rel.startsWith('dist');
+    if (rel === '') return true;
+    return !STAGING_EXCLUDES.has(rel.split(path.sep)[0]) && path.basename(rel) !== '.DS_Store';
   }
 });
 
-const vendorSource = process.env.AIDP_VENDOR_NODE_MODULES || path.join(WORKSPACE_ROOT, 'samples', 'npm-cli', 'node_modules');
-if (existsSync(vendorSource)) {
-  const vendorTarget = path.join(STAGING_PLUGIN, 'vendor', 'node_modules');
-  mkdirSync(path.dirname(vendorTarget), { recursive: true });
-  cpSync(vendorSource, vendorTarget, { recursive: true });
+const REQUIRED_VENDOR_DEPS = ['aidp-cli', 'aidp-typescript-client', 'oci-common'];
+const pluginVendorSource = path.join(PLUGIN_ROOT, 'vendor', 'node_modules');
+const vendorSource = process.env.AIDP_VENDOR_NODE_MODULES || pluginVendorSource;
+if (!existsSync(vendorSource)) {
+  throw new Error(
+    `Vendor node_modules not found. Set AIDP_VENDOR_NODE_MODULES, or provide ${pluginVendorSource}. `
+    + `The packaged plugin must bundle ${REQUIRED_VENDOR_DEPS.join(', ')}.`
+  );
 }
+const missingVendorDeps = REQUIRED_VENDOR_DEPS.filter((dep) => !existsSync(path.join(vendorSource, dep)));
+if (missingVendorDeps.length) {
+  throw new Error(`Vendor source ${vendorSource} is missing required dependencies: ${missingVendorDeps.join(', ')}.`);
+}
+const vendorTarget = path.join(STAGING_PLUGIN, 'vendor', 'node_modules');
+mkdirSync(path.dirname(vendorTarget), { recursive: true });
+cpSync(vendorSource, vendorTarget, { recursive: true });
 
 const tarPath = path.join(DIST_DIR, `${baseName}.tar.gz`);
 const zipPath = path.join(DIST_DIR, `${baseName}.zip`);
@@ -63,5 +73,5 @@ console.log(JSON.stringify({
   distDir: DIST_DIR,
   files: files.map((file) => path.relative(WORKSPACE_ROOT, file)),
   checksumFile: path.relative(WORKSPACE_ROOT, path.join(DIST_DIR, `${baseName}.sha256`)),
-  vendoredAidpCli: existsSync(vendorSource)
+  vendoredAidpCli: true
 }, null, 2));

--- a/ai/codex-plugins/plugins/ask-aidp/scripts/qa.mjs
+++ b/ai/codex-plugins/plugins/ask-aidp/scripts/qa.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import { spawn } from 'node:child_process';
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, readlinkSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const PLUGIN_ROOT = path.resolve(path.dirname(__filename), '..');
 const SERVER = path.join(PLUGIN_ROOT, 'mcp', 'ask-aidp-server.mjs');
+const EXPECTED_VERSION = '0.9.1';
+const EXPECTED_TOOLS = 43;
 const args = new Set(process.argv.slice(2));
 const live = args.has('--live');
 const workflow = args.has('--workflow');
@@ -19,10 +21,109 @@ function pluginManifestTest() {
   const manifestPath = path.join(PLUGIN_ROOT, '.codex-plugin', 'plugin.json');
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
   assert(manifest.name === 'ask-aidp', 'plugin name mismatch');
+  assert(manifest.version === EXPECTED_VERSION, `plugin version mismatch: expected ${EXPECTED_VERSION}, got ${manifest.version}`);
   assert(manifest.mcpServers === './.mcp.json', 'missing mcpServers manifest entry');
   assert(existsSync(path.join(PLUGIN_ROOT, '.mcp.json')), 'missing .mcp.json');
   assert(existsSync(SERVER), 'missing MCP server');
   assert(existsSync(path.join(PLUGIN_ROOT, 'skills', 'ask-aidp', 'SKILL.md')), 'missing skill');
+}
+
+function mcpConfigTest() {
+  const config = JSON.parse(readFileSync(path.join(PLUGIN_ROOT, '.mcp.json'), 'utf8'));
+  const server = config?.mcpServers?.['ask-aidp'];
+  assert(server, '.mcp.json must use the wrapped mcpServers.ask-aidp format');
+  assert(server.command === 'node', `.mcp.json command should be node, got ${server.command}`);
+  assert(server.cwd === '.', `.mcp.json cwd should be ".", got ${server.cwd}`);
+  const serverArgs = server.args || [];
+  assert(
+    serverArgs.some((arg) => arg.includes('mcp/ask-aidp-server.mjs')),
+    '.mcp.json args must point at mcp/ask-aidp-server.mjs'
+  );
+  for (const arg of serverArgs) {
+    assert(!path.isAbsolute(arg), `.mcp.json args must stay relative, got absolute ${arg}`);
+  }
+}
+
+function marketplaceManifestTest() {
+  const nestedRoot = path.resolve(PLUGIN_ROOT, '..', '..');
+  const repositoryRoot = path.resolve(PLUGIN_ROOT, '..', '..', '..', '..');
+  const nestedPath = path.join(nestedRoot, '.agents', 'plugins', 'marketplace.json');
+  const repositoryPath = path.join(repositoryRoot, '.agents', 'plugins', 'marketplace.json');
+  const hasNestedManifest = existsSync(nestedPath);
+  const hasRepositoryManifest = existsSync(repositoryPath);
+
+  // Packaged and installed plugin copies do not include either marketplace root.
+  if (!hasNestedManifest && !hasRepositoryManifest) return;
+  assert(hasNestedManifest, 'repository checkout is missing the nested ai/codex-plugins marketplace manifest');
+  assert(hasRepositoryManifest, 'repository checkout is missing the repository-root marketplace manifest');
+
+  const loadManifest = (manifestPath, marketplaceRoot, label) => {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    assert(manifest.name === 'oracle-aidp-codex', `unexpected ${label} marketplace name: ${manifest.name}`);
+    assert(Array.isArray(manifest.plugins), `${label} marketplace plugins must be an array`);
+
+    const resolvedPlugins = new Map();
+    for (const entry of manifest.plugins) {
+      assert(entry?.name, `${label} marketplace contains a plugin without a name`);
+      assert(!resolvedPlugins.has(entry.name), `${label} marketplace contains duplicate plugin ${entry.name}`);
+      assert(entry.source?.source === 'local', `${label} marketplace plugin ${entry.name} should use a local source`);
+      const resolved = path.resolve(marketplaceRoot, entry.source.path || '.');
+      assert(
+        existsSync(path.join(resolved, '.codex-plugin', 'plugin.json')),
+        `${label} marketplace plugin ${entry.name} path ${entry.source.path} does not resolve to a Codex plugin`
+      );
+      resolvedPlugins.set(entry.name, resolved);
+    }
+    return { manifest, resolvedPlugins };
+  };
+
+  const nested = loadManifest(nestedPath, nestedRoot, 'nested');
+  const repository = loadManifest(repositoryPath, repositoryRoot, 'repository-root');
+  const nestedPlugins = nested.resolvedPlugins;
+  const repositoryPlugins = repository.resolvedPlugins;
+  const nestedNames = [...nestedPlugins.keys()].sort();
+  const repositoryNames = [...repositoryPlugins.keys()].sort();
+  assert(
+    JSON.stringify(nestedNames) === JSON.stringify(repositoryNames),
+    'repository-root and nested marketplace manifests must list the same plugins'
+  );
+  assert(
+    JSON.stringify(nested.manifest.interface) === JSON.stringify(repository.manifest.interface),
+    'repository-root and nested marketplace interfaces must match'
+  );
+  for (const pluginName of nestedNames) {
+    const nestedEntry = nested.manifest.plugins.find((entry) => entry.name === pluginName);
+    const repositoryEntry = repository.manifest.plugins.find((entry) => entry.name === pluginName);
+    assert(
+      nestedPlugins.get(pluginName) === repositoryPlugins.get(pluginName),
+      `repository-root and nested marketplace entries for ${pluginName} must resolve to the same plugin`
+    );
+    assert(
+      nestedEntry.category === repositoryEntry.category &&
+        JSON.stringify(nestedEntry.policy) === JSON.stringify(repositoryEntry.policy),
+      `repository-root and nested marketplace metadata for ${pluginName} must match`
+    );
+  }
+  assert(nestedPlugins.get('ask-aidp') === PLUGIN_ROOT, 'marketplace ask-aidp entries must resolve to this plugin');
+}
+
+function symlinkTest() {
+  const problems = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        const target = readlinkSync(full);
+        const rel = path.relative(PLUGIN_ROOT, full);
+        if (path.isAbsolute(target)) problems.push(`absolute: ${rel} -> ${target}`);
+        else if (!existsSync(path.resolve(path.dirname(full), target))) problems.push(`broken: ${rel} -> ${target}`);
+      } else if (entry.isDirectory()) {
+        walk(full);
+      }
+    }
+  };
+  walk(PLUGIN_ROOT);
+  assert(problems.length === 0, `non-portable symlinks: ${problems.slice(0, 10).join('; ')}`);
 }
 
 function startServer(extraEnv = {}) {
@@ -37,13 +138,20 @@ function startServer(extraEnv = {}) {
   child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
   let nextId = 1;
   const pending = new Map();
+  const nonJsonLines = [];
   const timer = setInterval(() => {
     let index;
     while ((index = stdout.indexOf('\n')) >= 0) {
       const line = stdout.slice(0, index);
       stdout = stdout.slice(index + 1);
       if (!line.trim()) continue;
-      const message = JSON.parse(line);
+      let message;
+      try {
+        message = JSON.parse(line);
+      } catch {
+        nonJsonLines.push(line.slice(0, 200));
+        continue;
+      }
       if (pending.has(message.id)) {
         const { resolve, reject } = pending.get(message.id);
         pending.delete(message.id);
@@ -68,6 +176,9 @@ function startServer(extraEnv = {}) {
         });
       });
     },
+    nonJsonLines() {
+      return nonJsonLines;
+    },
     stop() {
       clearInterval(timer);
       child.stdin.end();
@@ -82,16 +193,29 @@ function toolText(result) {
 
 async function main() {
   pluginManifestTest();
+  mcpConfigTest();
+  marketplaceManifestTest();
+  symlinkTest();
   const env = {};
   const localAidp = path.resolve(PLUGIN_ROOT, '..', '..', 'samples', 'npm-cli', 'node_modules', '.bin', process.platform === 'win32' ? 'aidp.cmd' : 'aidp');
   if (!process.env.AIDP_CLI_BIN && existsSync(localAidp)) env.AIDP_CLI_BIN = localAidp;
 
   const server = startServer(env);
   try {
-    const init = await server.request('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'ask-aidp-qa', version: '0.9.0' } });
+    const init = await server.request('initialize', { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'ask-aidp-qa', version: EXPECTED_VERSION } });
     assert(init.serverInfo.name === 'ask-aidp', 'server did not initialize as ask-aidp');
+    assert(init.serverInfo.version === EXPECTED_VERSION, `server version mismatch: expected ${EXPECTED_VERSION}, got ${init.serverInfo.version}`);
 
     const list = await server.request('tools/list');
+    assert(
+      list.tools.length === EXPECTED_TOOLS,
+      `tools/list returned ${list.tools.length} tools, expected ${EXPECTED_TOOLS}`
+    );
+    const tableWithDataTool = list.tools.find((tool) => tool.name === 'aidp_create_table_with_data');
+    assert(
+      tableWithDataTool?.inputSchema?.properties?.csvIncludeHeader?.const === false,
+      'aidp_create_table_with_data must reject CSV headers because create-data-table reads positionally'
+    );
     const names = list.tools.map((tool) => tool.name);
     for (const name of [
       'aidp_cli',
@@ -226,6 +350,18 @@ async function main() {
     assert(!uploadDryRun.isError, `upload dry run failed: ${toolText(uploadDryRun)}`);
     const uploadPlan = JSON.parse(toolText(uploadDryRun));
     assert(uploadPlan.entryCount === 1, 'upload dry run expected one file');
+    assert(
+      uploadPlan.implementation === 'aidp-typescript-client WorkspaceObjectClient#createWorkspaceObject',
+      'upload dry run should use the WorkspaceObjectClient implementation'
+    );
+    assert(
+      uploadPlan.entries[0].request.aiDataPlatformId === '<aiDataPlatformId>',
+      'upload dry run should use an instance ID placeholder when only workspaceKey is configured'
+    );
+    assert(
+      uploadPlan.entries[0].request.createWorkspaceObjectDetails.startsWith('<base64:'),
+      'upload dry run should return a base64 placeholder instead of file contents'
+    );
 
     const globDir = path.join(PLUGIN_ROOT, 'qa-runs', 'glob-top-level');
     rmSync(globDir, { recursive: true, force: true });
@@ -519,8 +655,18 @@ async function main() {
     assert(tableWithDataPlan.command.includes('schema create-data-table'), 'table with data command mismatch');
     assert(tableWithDataPlan.body.managedTableDefinition.managedTableDataFormat === 'DELTA', 'table with data managed format mismatch');
     assert(tableWithDataPlan.body.fileFormat === 'CSV', 'table with data file format mismatch');
-    assert(tableWithDataPlan.body.selectedColumns.includes('amount'), 'table with data selected columns mismatch');
-    assert(/id,amount,status/.test(tableWithDataPlan.dataPreview), 'table with data CSV preview mismatch');
+    assert(
+      JSON.stringify(tableWithDataPlan.body.selectedColumns) === JSON.stringify(['_c0', '_c1', '_c2']),
+      'table with data selected columns should be positional (_c0/_c1/_c2) for headerless inline rows'
+    );
+    assert(
+      tableWithDataPlan.body.tableFields.some((field) => field.fieldName === 'amount'),
+      'table with data tableFields should carry the amount column name'
+    );
+    assert(
+      /(^|\n)1,10\.5,new(\n|$)/.test(tableWithDataPlan.dataPreview) && !/id,amount,status/.test(tableWithDataPlan.dataPreview),
+      'table with data CSV preview should be headerless data rows'
+    );
 
     const csvTableSql = await server.request('tools/call', {
       name: 'aidp_generate_csv_table_sql',
@@ -676,6 +822,9 @@ async function main() {
       assert(summary.taskRuns.length === 3, 'workflow did not return three task runs');
       writeFileSync(path.join(PLUGIN_ROOT, 'qa-live-result.json'), JSON.stringify(summary, null, 2));
     }
+
+    const stray = server.nonJsonLines();
+    assert(stray.length === 0, `non-JSON output on stdout: ${stray.slice(0, 5).join(' | ')}`);
   } finally {
     server.stop();
   }

--- a/ai/codex-plugins/plugins/ask-aidp/skills/ask-aidp/CLI_COMMANDS.md
+++ b/ai/codex-plugins/plugins/ask-aidp/skills/ask-aidp/CLI_COMMANDS.md
@@ -202,7 +202,7 @@ Roles, role members, and role permissions.
 Schemas, tables, views, and schema permissions.
 
 - `aidp schema create` - Creates a schema.
-- `aidp schema create-data-table` - Creates a managed table with data loaded from a sample file.
+- `aidp schema create-data-table` - Creates a managed table with data loaded from a sample file. CSV input is read positionally: use a headerless file and `_c0`, `_c1`, ... in `selectedColumns`, with real names and types in `tableFields`.
 - `aidp schema create-table` - Creates a table.
 - `aidp schema create-view` - Creates a view.
 - `aidp schema delete` - Deletes a schema.

--- a/ai/codex-plugins/plugins/ask-aidp/skills/ask-aidp/SKILL.md
+++ b/ai/codex-plugins/plugins/ask-aidp/skills/ask-aidp/SKILL.md
@@ -14,7 +14,7 @@ When the Ask AIDP MCP tools are available, prefer them over shelling out manuall
 - `aidp_check_connection`: verify workspace and optional cluster access.
 - `aidp_notebook_workflow`: create any N notebooks, create a sequential workflow, run it, export task outputs, and collect cluster logs.
 - `aidp_three_notebook_workflow`: compatibility alias for a three-notebook workflow.
-- `aidp_upload_workspace_code`: upload local code files or a directory tree to an AIDP workspace path.
+- `aidp_upload_workspace_code`: use the native TypeScript SDK `WorkspaceObjectClient` to upload local code files or a directory tree to an AIDP workspace path.
 - `aidp_create_git_folder`: connect to Git and fetch code into a Git-backed AIDP workspace folder.
 - `aidp_git_commit_push`: use the native TypeScript SDK `GitClient` to stage files, commit, and push a Git-backed workspace folder.
 - `aidp_git_pull`: use the native TypeScript SDK `GitClient` to pull remote changes into a Git-backed workspace folder.
@@ -50,7 +50,7 @@ When the Ask AIDP MCP tools are available, prefer them over shelling out manuall
 - `aidp_rest_api_reference`: summarize, search, or inspect the generated catalog of documented REST operations.
 - `aidp_rest`: make an OCI-signed request to any method/path pair in the documented REST catalog.
 
-If tools are not available, use `aidp-cli` directly with argument arrays or shell commands. For workspace Git repository push, pull, status, diff, branch, merge, rebase, and reset operations, prefer the native SDK-backed Git tools because those operations are not covered by `aidp-cli`.
+If tools are not available, use `aidp-cli` directly with argument arrays or shell commands. For workspace code upload and Git repository push, pull, status, diff, branch, merge, rebase, and reset operations, prefer the native SDK-backed tools.
 
 ## Full CLI Coverage
 
@@ -103,13 +103,13 @@ For live operations that create or update resources, write evidence to a local r
 
 When generating notebooks, organize code into focused cells with comments. Keep setup/common values together, keep related work together, and keep validation/output markers together. For SQL notebooks, preserve `%sql` as the first line of the SQL cell and use SQL comments (`-- ...`) inside that cell.
 
-For catalog/schema/table creation and lookup, prefer the dedicated convenience tools when their input shape fits. Use `aidp_list_catalogs` for "show/list/get catalogs", `aidp_get_catalog` for one catalog, `aidp_create_catalog` for general catalog creation, and `aidp_create_external_catalog` when the user specifically wants an external catalog. Use `dryRun: true` first when the user is deciding on names, keys, table columns, source type, connection properties, or sample data. Use `aidp_create_table_with_data` when the user asks to create a table and insert or load initial data into it. Be clear that this wraps `schema create-data-table` for a new managed table with an initial load; for appending to an existing table, use `aidp_cli` or a notebook/workflow if the environment exposes that operation.
+For catalog/schema/table creation and lookup, prefer the dedicated convenience tools when their input shape fits. Use `aidp_list_catalogs` for "show/list/get catalogs", `aidp_get_catalog` for one catalog, `aidp_create_catalog` for general catalog creation, and `aidp_create_external_catalog` when the user specifically wants an external catalog. Use `dryRun: true` first when the user is deciding on names, keys, table columns, source type, connection properties, or sample data. Use `aidp_create_table_with_data` when the user asks to create a table and insert or load initial data into it. Be clear that this wraps `schema create-data-table` for a new managed table with an initial load; inline rows are staged as headerless CSV with positional `selectedColumns` (`_c0`, `_c1`, ...) while `tableFields` carries the real names and types. For appending to an existing table, use `aidp_cli` or a notebook/workflow if the environment exposes that operation.
 
 For CSV-backed tables where the first row should be treated as column headers, prefer `aidp_generate_csv_table_sql` and run the generated SQL in an AIDP notebook or workflow. The generated SQL should use `USING CSV` and `OPTIONS (path '<path>', header 'true')`, matching the documented notebook SQL pattern.
 
 For workflow healing, prefer `aidp_auto_heal_workflow`. Use `dryRun: true` first unless the user clearly asks to perform the repair. If task keys are omitted, the tool selects task runs with failed/error statuses from the target job run.
 
-For workspace code, use `aidp_upload_workspace_code` for local files/directories and `aidp_create_git_folder` for Git-backed workspace folders. For Git push/pull/status/diff/branch workflows inside a Git-backed workspace folder, use the `aidp_git_*` tools; these route through the TypeScript SDK `GitClient` while the rest of the plugin remains CLI-backed. Prefer passing `gitFolderPath`; when `gitRepositoryKey` is omitted, the plugin resolves it with `WorkspaceObjectClient#listWorkspaceObjects` and the Git folder metadata `repoKey`. Use dry-run before uploading many files or performing mutating Git operations.
+For workspace code, use `aidp_upload_workspace_code` for local files/directories and `aidp_create_git_folder` for Git-backed workspace folders. Uploads route through the TypeScript SDK `WorkspaceObjectClient`; dry-run returns request placeholders without reading or base64-encoding file contents. For Git push/pull/status/diff/branch workflows inside a Git-backed workspace folder, use the `aidp_git_*` tools; these route through the TypeScript SDK `GitClient`. Prefer passing `gitFolderPath`; when `gitRepositoryKey` is omitted, the plugin resolves it with `WorkspaceObjectClient#listWorkspaceObjects` and the Git folder metadata `repoKey`. Use dry-run before uploading many files or performing mutating Git operations.
 
 For file paths in notebooks, follow AIDP Workbench file access patterns:
 


### PR DESCRIPTION
## Summary

- update the Ask AIDP Codex plugin from 0.9.0 to 0.9.1 while preserving the Oracle Samples REST and AI Compute capabilities
- fix inline `create-data-table` loads to stage headerless CSV and use positional `_c0`, `_c1`, and related source columns
- use `WorkspaceObjectClient#createWorkspaceObject` for workspace uploads and keep dry runs independent of live credentials or file contents
- harden offline packaging so required `aidp-cli`, `aidp-typescript-client`, and `oci-common` dependencies cannot be omitted silently
- expand static QA for plugin metadata, MCP configuration, tool counts, stdout protocol safety, symlinks, upload dry runs, and table-load regressions
- add a repository-root Codex marketplace manifest while preserving the nested local marketplace manifest
- update installation, restart, verification, configuration, and packaging documentation

## Marketplace installation fix

The documented Git marketplace command sparse-checked out `ai/codex-plugins`, but Codex still looked for a supported marketplace manifest at the checkout root. The existing manifest was nested under `ai/codex-plugins`, so remote registration failed before any plugin could be discovered.

This change adds `.agents/plugins/marketplace.json` at the repository root and updates the command to include both sparse paths:

```bash
codex plugin marketplace add oracle-samples/oracle-aidp-samples \
    --ref main \
    --sparse .agents \
    --sparse ai/codex-plugins
```

The existing `ai/codex-plugins/.agents/plugins/marketplace.json` remains supported for local directory registration. QA verifies that both manifests expose the same five plugins, resolve to the same plugin directories, and retain matching marketplace metadata.

## Validation

- `node --check` passed for the MCP server, QA script, packaging script, and CLI reference generator
- source QA passed with 43 MCP tools, 242 CLI commands, and 257 REST operations
- local repository-root and nested marketplace installations both installed and enabled Ask AIDP 0.9.1
- remote Git sparse marketplace registration from the pushed fork branch passed with both sparse paths
- remote marketplace upgrade, plugin installation, MCP registration, and installed-cache QA passed
- fail-closed packaging behavior was verified when vendor dependencies were absent
- 0.9.1 tarball and ZIP packaging passed SHA-256, archive-integrity, required-dependency, and extracted-package QA checks
- `git diff --check` passed

Fixes #97
