### PR TITLE
docs: clarify Ask-AIDP setup prerequisites for Claude and Codex

### DIFF
--- a/ai/claude-code-plugins/ask-aidp/README.md
+++ b/ai/claude-code-plugins/ask-aidp/README.md
@@ -37,16 +37,45 @@ It provides:
 - Claude Code with the `plugin` subcommand, verified on `2.1.250`.
 - Node.js available to Claude Code (verify with `node --version`).
 - OCI config and credentials that can access the target AIDP instance.
-- The latest `aidp-cli` from
+- AIDP CLI (`aidp`), required for full plugin functionality. Install the latest `aidp-cli` from
   [`oracle-samples/aidataplatform-sdk`](https://github.com/oracle-samples/aidataplatform-sdk),
   either on `PATH` or selected with `AIDP_CLI_BIN`.
 - The latest `aidp-typescript-client` and `oci-common` packages when using the
-  native SDK workspace upload and Git tools.
+  native SDK workspace upload and Git tools; `oci-common` is also required for
+  signed REST calls.
+
+AIDP CLI (`aidp`) and OCI CLI (`oci`) are different tools. Installing OCI CLI
+does not install AIDP CLI. OCI CLI is optional when you configure OCI API-key
+credentials directly as described below. The upstream AIDP installation guide
+includes OCI CLI for credential setup and session-token authentication.
 
 This GitHub directory is the plugin's source distribution. It does **not**
 contain generated `dist/` archives or a vendored `node_modules` tree. The build
 script can create offline archives for a separate release process, but those
 artifacts are not published here.
+
+### Set up and verify AIDP CLI
+
+Before connecting the plugin, follow the
+[AIDP CLI installation instructions](https://github.com/oracle-samples/aidataplatform-sdk#cli)
+to install the CLI and its matching SDK package. Installing this plugin from
+GitHub does not install those dependencies. Then verify in the shell that will
+launch Claude Code:
+
+```sh
+node --version
+aidp --help
+```
+
+If `aidp` is not on `PATH`, set `AIDP_CLI_BIN` to its absolute executable path.
+Verify that executable with `"$AIDP_CLI_BIN" --help` on macOS/Linux or
+`& $env:AIDP_CLI_BIN --help` in PowerShell. Restart Claude Code after changing
+its environment.
+
+Without AIDP CLI, CLI-backed tools such as connection checks, notebook workflows,
+and catalog operations fail. Reference tools may still respond, and direct
+SDK/REST tools can work with their own dependencies and credentials, but that
+does not verify full plugin functionality.
 
 For file work in notebooks, use AIDP Workbench path patterns such as `/Volumes/<catalog>/<schema>/<volume>/<file>`, `/Workspace/<folder>/<file>`, `file:///Volumes/...`, `file:///Workspace/...`, and `oci://<bucket>@<namespace>/<folder-or-file>`.
 
@@ -107,6 +136,27 @@ claude plugin validate ./oracle-aidp-samples/ai/claude-code-plugins/ask-aidp/.cl
 ```
 
 ## Configure
+
+### Configure OCI credentials
+
+For API-key authentication, OCI CLI is not required. Reuse a valid OCI profile or
+follow [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two):
+
+1. Use an IAM user with permission to access the target AIDP resources and upload
+   the public API signing key under that user's API Keys in OCI Console.
+2. Save the generated profile in `~/.oci/config` on macOS/Linux or
+   `%USERPROFILE%\.oci\config` on Windows. Include `user`, `tenancy`,
+   `fingerprint`, `region`, and `key_file`, pointing to the private PEM key.
+3. Restrict private-key access to your user. Set `AIDP_AUTH=api_key` and
+   `OCI_PROFILE` to the profile name; set `OCI_CONFIG_FILE` for a custom location.
+
+If you choose OCI CLI-assisted setup, install
+[OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
+and use `oci setup config` for an API-key profile or `oci session authenticate`
+for a session-token profile. CLI calls using a session-token profile need
+`AIDP_AUTH=security_token` and the matching `OCI_PROFILE`.
+
+### Set the plugin environment
 
 Provide AIDP/OCI settings through environment variables in the shell you launch Claude Code
 from. The plugin's `.mcp.json` does not inject environment variables, so the MCP server sees

--- a/ai/claude-code-plugins/ask-aidp/README.md
+++ b/ai/claude-code-plugins/ask-aidp/README.md
@@ -40,14 +40,18 @@ It provides:
 - AIDP CLI (`aidp`), required for full plugin functionality. Install the latest `aidp-cli` from
   [`oracle-samples/aidataplatform-sdk`](https://github.com/oracle-samples/aidataplatform-sdk),
   either on `PATH` or selected with `AIDP_CLI_BIN`.
+- OCI CLI (`oci`), required to create the initial token when using the documented
+  session-token authentication flow (`oci session authenticate`). It can be
+  skipped when configuring API-key credentials directly.
 - The latest `aidp-typescript-client` and `oci-common` packages when using the
   native SDK workspace upload and Git tools; `oci-common` is also required for
   signed REST calls.
 
 AIDP CLI (`aidp`) and OCI CLI (`oci`) are different tools. Installing OCI CLI
-does not install AIDP CLI. OCI CLI is optional when you configure OCI API-key
-credentials directly as described below. The upstream AIDP installation guide
-includes OCI CLI for credential setup and session-token authentication.
+does not install AIDP CLI. AIDP CLI defaults to `security_token` unless overridden.
+For API-key authentication, explicitly set `AIDP_AUTH=api_key` so Ask-AIDP passes
+the correct authentication mode to CLI calls. The environment samples below use
+this API-key alternative.
 
 This GitHub directory is the plugin's source distribution. It does **not**
 contain generated `dist/` archives or a vendored `node_modules` tree. The build
@@ -139,6 +143,15 @@ claude plugin validate ./oracle-aidp-samples/ai/claude-code-plugins/ask-aidp/.cl
 
 ### Configure OCI credentials
 
+For session-token authentication, install
+[OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
+and create the initial token with `oci session authenticate`. Then set
+`AIDP_AUTH=security_token` and `OCI_PROFILE` to the generated profile name before
+launching the assistant. AIDP CLI consumes the existing session credentials;
+setting `AIDP_AUTH` does not create a token or perform the initial login. Follow
+[Oracle's session-token instructions](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm)
+to validate, refresh, or reauthenticate the session when needed.
+
 For API-key authentication, OCI CLI is not required. Reuse a valid OCI profile or
 follow [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two):
 
@@ -150,11 +163,8 @@ follow [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaa
 3. Restrict private-key access to your user. Set `AIDP_AUTH=api_key` and
    `OCI_PROFILE` to the profile name; set `OCI_CONFIG_FILE` for a custom location.
 
-If you choose OCI CLI-assisted setup, install
-[OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
-and use `oci setup config` for an API-key profile or `oci session authenticate`
-for a session-token profile. CLI calls using a session-token profile need
-`AIDP_AUTH=security_token` and the matching `OCI_PROFILE`.
+If OCI CLI is already installed, `oci setup config` can also help create an
+API-key profile.
 
 ### Set the plugin environment
 

--- a/ai/claude-code-plugins/ask-aidp/examples/aidp.env.sample
+++ b/ai/claude-code-plugins/ask-aidp/examples/aidp.env.sample
@@ -19,6 +19,10 @@ export AIDP_WORKSPACE_KEY="<workspace-key>"
 export AIDP_CLUSTER_KEY="<cluster-key>"
 
 # Recommended for OCI config profiles using user, tenancy, fingerprint, and key_file.
+# OCI CLI is optional for this API-key setup; configure credentials directly:
+# https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two
+# Then set OCI_PROFILE to the profile containing user, tenancy, fingerprint,
+# region, and key_file, and set OCI_CONFIG_FILE if the config is not default.
 export AIDP_AUTH="api_key"
 
 # Usually DEFAULT unless users keep AIDP access in another OCI profile.
@@ -30,7 +34,10 @@ export OCI_PROFILE="DEFAULT"
 # Optional: OCI region, useful when the CLI or profile needs an explicit region.
 # export OCI_REGION="us-ashburn-1"
 
-# Optional: absolute path to aidp if not using the plugin-vendored CLI or PATH.
+# AIDP CLI (aidp) is required for full functionality; OCI CLI (oci) is different.
+# GitHub plugin installs do not bundle AIDP CLI. Install it separately.
+# Optional override: absolute path to aidp when it is not on PATH.
+# Offline archives can provide a vendored CLI instead.
 # export AIDP_CLI_BIN="/absolute/path/to/aidp"
 
 # Optional: cluster display name if workflow helpers should use a name instead of key.

--- a/ai/claude-code-plugins/ask-aidp/examples/aidp.env.sample
+++ b/ai/claude-code-plugins/ask-aidp/examples/aidp.env.sample
@@ -18,12 +18,20 @@ export AIDP_WORKSPACE_KEY="<workspace-key>"
 # Required only for workflow runs, cluster checks, and log collection.
 export AIDP_CLUSTER_KEY="<cluster-key>"
 
-# Recommended for OCI config profiles using user, tenancy, fingerprint, and key_file.
+# This sample selects API-key authentication explicitly because AIDP CLI defaults
+# to security_token. Keep api_key for profiles with user, tenancy, fingerprint,
+# and key_file.
 # OCI CLI is optional for this API-key setup; configure credentials directly:
 # https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two
 # Then set OCI_PROFILE to the profile containing user, tenancy, fingerprint,
 # region, and key_file, and set OCI_CONFIG_FILE if the config is not default.
 export AIDP_AUTH="api_key"
+
+# Session-token alternative: install OCI CLI and run `oci session authenticate`
+# to create the initial token, then change AIDP_AUTH to security_token and set
+# OCI_PROFILE to the generated profile name. Setting AIDP_AUTH alone does not
+# create a token or perform login.
+# https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm
 
 # Usually DEFAULT unless users keep AIDP access in another OCI profile.
 export OCI_PROFILE="DEFAULT"

--- a/ai/codex-plugins/plugins/ask-aidp/README.md
+++ b/ai/codex-plugins/plugins/ask-aidp/README.md
@@ -7,17 +7,46 @@ This plugin connects Codex to Oracle AI Data Platform Workbench through every do
 - Codex CLI with the `plugin` subcommand and Node.js available to Codex. The
   installation flow is verified on `codex-cli 0.147.0`.
 - OCI config and credentials that can access the target AIDP instance.
-- The latest `aidp-cli` from
+- AIDP CLI (`aidp`), required for full plugin functionality. Install the latest `aidp-cli` from
   [`oracle-samples/aidataplatform-sdk`](https://github.com/oracle-samples/aidataplatform-sdk),
   either on `PATH` or selected with `AIDP_CLI_BIN`.
 - The latest `aidp-typescript-client` and `oci-common` packages when using the
-  native SDK workspace upload and Git tools.
+  native SDK workspace upload and Git tools; `oci-common` is also required for
+  signed REST calls.
+
+AIDP CLI (`aidp`) and OCI CLI (`oci`) are different tools. Installing OCI CLI
+does not install AIDP CLI. OCI CLI is optional when you configure OCI API-key
+credentials directly as described below. The upstream AIDP installation guide
+includes OCI CLI for credential setup and session-token authentication.
 
 This GitHub directory is the plugin's source distribution. It does **not** contain
 generated `dist/` tarballs, zip files, or a vendored `node_modules` tree. Install the
 plugin from the GitHub marketplace as described below. The build script can create
 offline archives for a separate release process, but those archives are not published
 here.
+
+### Set up and verify AIDP CLI
+
+Before connecting the plugin, follow the
+[AIDP CLI installation instructions](https://github.com/oracle-samples/aidataplatform-sdk#cli)
+to install the CLI and its matching SDK package. Installing this plugin from
+GitHub does not install those dependencies. Then verify in the shell that will
+launch Codex:
+
+```sh
+node --version
+aidp --help
+```
+
+If `aidp` is not on `PATH`, set `AIDP_CLI_BIN` to its absolute executable path.
+Verify that executable with `"$AIDP_CLI_BIN" --help` on macOS/Linux or
+`& $env:AIDP_CLI_BIN --help` in PowerShell. Restart Codex after changing its
+environment.
+
+Without AIDP CLI, CLI-backed tools such as connection checks, notebook workflows,
+and catalog operations fail. Reference tools may still respond, and direct
+SDK/REST tools can work with their own dependencies and credentials, but that
+does not verify full plugin functionality.
 
 For file work in notebooks, use AIDP Workbench path patterns such as `/Volumes/<catalog>/<schema>/<volume>/<file>`, `/Workspace/<folder>/<file>`, `file:///Volumes/...`, `file:///Workspace/...`, and `oci://<bucket>@<namespace>/<folder-or-file>`.
 
@@ -94,6 +123,27 @@ Expected: `"ok": true`, 43 MCP tools, 242 CLI commands, and 257 REST operations.
 
 ## Configure AIDP
 
+### Configure OCI credentials
+
+For API-key authentication, OCI CLI is not required. Reuse a valid OCI profile or
+follow [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two):
+
+1. Use an IAM user with permission to access the target AIDP resources and upload
+   the public API signing key under that user's API Keys in OCI Console.
+2. Save the generated profile in `~/.oci/config` on macOS/Linux or
+   `%USERPROFILE%\.oci\config` on Windows. Include `user`, `tenancy`,
+   `fingerprint`, `region`, and `key_file`, pointing to the private PEM key.
+3. Restrict private-key access to your user. Set `AIDP_AUTH=api_key` and
+   `OCI_PROFILE` to the profile name; set `OCI_CONFIG_FILE` for a custom location.
+
+If you choose OCI CLI-assisted setup, install
+[OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
+and use `oci setup config` for an API-key profile or `oci session authenticate`
+for a session-token profile. CLI calls using a session-token profile need
+`AIDP_AUTH=security_token` and the matching `OCI_PROFILE`.
+
+### Set the plugin environment
+
 Use [`examples/aidp.env.sample`](./examples/aidp.env.sample) as the template. Do
 not distribute a completed `aidp.env`, because it identifies a user's OCI profile,
 AIDP instance, workspace, and cluster.
@@ -140,11 +190,6 @@ export AIDP_CLI_BIN="/absolute/path/to/aidp"
 ```powershell
 $env:AIDP_CLI_BIN = "C:\path\to\aidp.cmd"
 ```
-
-If `oci login` does not work, configure OCI API key authentication using
-[Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two).
-Set `AIDP_AUTH=api_key`, select the profile with `OCI_PROFILE`, and set
-`OCI_CONFIG_FILE` when the OCI config is not in its default location.
 
 ## Build Offline Archives — Maintainers
 

--- a/ai/codex-plugins/plugins/ask-aidp/README.md
+++ b/ai/codex-plugins/plugins/ask-aidp/README.md
@@ -10,14 +10,18 @@ This plugin connects Codex to Oracle AI Data Platform Workbench through every do
 - AIDP CLI (`aidp`), required for full plugin functionality. Install the latest `aidp-cli` from
   [`oracle-samples/aidataplatform-sdk`](https://github.com/oracle-samples/aidataplatform-sdk),
   either on `PATH` or selected with `AIDP_CLI_BIN`.
+- OCI CLI (`oci`), required to create the initial token when using the documented
+  session-token authentication flow (`oci session authenticate`). It can be
+  skipped when configuring API-key credentials directly.
 - The latest `aidp-typescript-client` and `oci-common` packages when using the
   native SDK workspace upload and Git tools; `oci-common` is also required for
   signed REST calls.
 
 AIDP CLI (`aidp`) and OCI CLI (`oci`) are different tools. Installing OCI CLI
-does not install AIDP CLI. OCI CLI is optional when you configure OCI API-key
-credentials directly as described below. The upstream AIDP installation guide
-includes OCI CLI for credential setup and session-token authentication.
+does not install AIDP CLI. AIDP CLI defaults to `security_token` unless overridden.
+For API-key authentication, explicitly set `AIDP_AUTH=api_key` so Ask-AIDP passes
+the correct authentication mode to CLI calls. The environment samples below use
+this API-key alternative.
 
 This GitHub directory is the plugin's source distribution. It does **not** contain
 generated `dist/` tarballs, zip files, or a vendored `node_modules` tree. Install the
@@ -125,6 +129,15 @@ Expected: `"ok": true`, 43 MCP tools, 242 CLI commands, and 257 REST operations.
 
 ### Configure OCI credentials
 
+For session-token authentication, install
+[OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
+and create the initial token with `oci session authenticate`. Then set
+`AIDP_AUTH=security_token` and `OCI_PROFILE` to the generated profile name before
+launching the assistant. AIDP CLI consumes the existing session credentials;
+setting `AIDP_AUTH` does not create a token or perform the initial login. Follow
+[Oracle's session-token instructions](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm)
+to validate, refresh, or reauthenticate the session when needed.
+
 For API-key authentication, OCI CLI is not required. Reuse a valid OCI profile or
 follow [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two):
 
@@ -136,11 +149,8 @@ follow [Oracle's API signing key instructions](https://docs.oracle.com/en-us/iaa
 3. Restrict private-key access to your user. Set `AIDP_AUTH=api_key` and
    `OCI_PROFILE` to the profile name; set `OCI_CONFIG_FILE` for a custom location.
 
-If you choose OCI CLI-assisted setup, install
-[OCI CLI](https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/cliinstall.htm)
-and use `oci setup config` for an API-key profile or `oci session authenticate`
-for a session-token profile. CLI calls using a session-token profile need
-`AIDP_AUTH=security_token` and the matching `OCI_PROFILE`.
+If OCI CLI is already installed, `oci setup config` can also help create an
+API-key profile.
 
 ### Set the plugin environment
 

--- a/ai/codex-plugins/plugins/ask-aidp/examples/aidp.env.sample
+++ b/ai/codex-plugins/plugins/ask-aidp/examples/aidp.env.sample
@@ -19,7 +19,7 @@ export AIDP_WORKSPACE_KEY="<workspace-key>"
 export AIDP_CLUSTER_KEY="<cluster-key>"
 
 # Recommended for OCI config profiles using user, tenancy, fingerprint, and key_file.
-# If `oci login` does not work, configure OCI API key authentication by following:
+# OCI CLI is optional for this API-key setup; configure credentials directly:
 # https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two
 # Then set OCI_PROFILE to the profile containing user, tenancy, fingerprint,
 # region, and key_file, and set OCI_CONFIG_FILE if the config is not default.
@@ -34,7 +34,10 @@ export OCI_PROFILE="DEFAULT"
 # Optional: OCI region, useful when the CLI or profile needs an explicit region.
 # export OCI_REGION="us-ashburn-1"
 
-# Optional: absolute path to aidp if not using the plugin-vendored CLI or PATH.
+# AIDP CLI (aidp) is required for full functionality; OCI CLI (oci) is different.
+# GitHub plugin installs do not bundle AIDP CLI. Install it separately.
+# Optional override: absolute path to aidp when it is not on PATH.
+# Offline archives can provide a vendored CLI instead.
 # export AIDP_CLI_BIN="/absolute/path/to/aidp"
 
 # Optional: cluster display name if workflow helpers should use a name instead of key.

--- a/ai/codex-plugins/plugins/ask-aidp/examples/aidp.env.sample
+++ b/ai/codex-plugins/plugins/ask-aidp/examples/aidp.env.sample
@@ -18,12 +18,20 @@ export AIDP_WORKSPACE_KEY="<workspace-key>"
 # Required only for workflow runs, cluster checks, and log collection.
 export AIDP_CLUSTER_KEY="<cluster-key>"
 
-# Recommended for OCI config profiles using user, tenancy, fingerprint, and key_file.
+# This sample selects API-key authentication explicitly because AIDP CLI defaults
+# to security_token. Keep api_key for profiles with user, tenancy, fingerprint,
+# and key_file.
 # OCI CLI is optional for this API-key setup; configure credentials directly:
 # https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two
 # Then set OCI_PROFILE to the profile containing user, tenancy, fingerprint,
 # region, and key_file, and set OCI_CONFIG_FILE if the config is not default.
 export AIDP_AUTH="api_key"
+
+# Session-token alternative: install OCI CLI and run `oci session authenticate`
+# to create the initial token, then change AIDP_AUTH to security_token and set
+# OCI_PROFILE to the generated profile name. Setting AIDP_AUTH alone does not
+# create a token or perform login.
+# https://docs.oracle.com/en-us/iaas/Content/API/SDKDocs/clitoken.htm
 
 # Usually DEFAULT unless users keep AIDP access in another OCI profile.
 export OCI_PROFILE="DEFAULT"


### PR DESCRIPTION
# Description

Ask-AIDP setup needs to distinguish the required AIDP CLI from the OCI CLI authentication setup dependency. Update both Claude Code and Codex guides: AIDP CLI (`aidp`) is required for full functionality, and OCI CLI (`oci`) is required to create the initial token through the documented session-token login flow. Direct API-key configuration is an alternative that does not require OCI CLI.

Document that AIDP CLI defaults to `security_token`, so API-key users must explicitly set `AIDP_AUTH=api_key`. Explain that selecting an authentication mode does not create a token, link session login and renewal instructions, and align both environment samples. Add CLI installation and verification steps, describe limitations without AIDP CLI, and identify `oci-common` as a signed REST dependency.

Documentation only; no runtime changes or new dependencies. No linked issue.

## Type of change

- [x] Documentation update

# How Has This Been Tested?

- [x] Whitespace validation with `git diff --check`.
- [x] Shell syntax validation with `bash -n ai/claude-code-plugins/ask-aidp/examples/aidp.env.sample ai/codex-plugins/plugins/ask-aidp/examples/aidp.env.sample`.
- [x] Confirmed both environment samples are identical.
- [x] Reviewed authentication behavior against plugin code, upstream AIDP CLI authentication providers, and Oracle's session-token documentation.
- [x] Live read-only workspace lookups succeeded through both repository MCP servers using an existing API-key profile and installed AIDP CLI 1.0.0, with OCI CLI absent from the test PATH and subprocess calls restricted to the explicit AIDP CLI executable. Each lookup returned the expected workspace in ACTIVE state.

Switching the same API-key-only profile to `security_token` failed in both plugins; a follow-up through the installed connector returned HTTP 401 `NotAuthenticated`. Initial session-token creation was not live-tested because environment access controls blocked OCI session commands. The session-token setup requirement is supported by Oracle documentation and source inspection. Live results cover the workspace lookup with the tested CLI version, not every plugin operation.

# Checklist

- [x] Followed existing documentation style.
- [x] Performed a self-review.
- [x] Updated both platform guides and environment samples consistently.
